### PR TITLE
TDK-7908: L2 Tests for TV settings

### DIFF
--- a/docs/pages/tvSettings_L2_Low-Level_TestSpecification.md
+++ b/docs/pages/tvSettings_L2_Low-Level_TestSpecification.md
@@ -411,7 +411,7 @@ graph TB
     C -->|match| D[TvTerm API Call]
     D -->|tvERROR_NONE| E[Test Case Success]
     D -->|Not tvERROR_NONE| D1[Test Case Fail]
-
+```
 
 ### Test 10
 
@@ -833,7 +833,7 @@ If user chose to run the test in interactive mode, then the test case has to be 
 ```mermaid
 graph TB
     A[TvInit API Call] -->|Success| Loop{Iterate through various <br> Color temperature}
-    Loop -->B[SetColorTemperature API Call]
+    Loop --> B[SetColorTemperature API Call]
     A -->|Failure| A1[Test case fail]
     B -->|Success| D[GetColorTemperature API Call]
     D -->| Success <br> Get and set matches|Loop
@@ -1329,10 +1329,10 @@ graph TB
     B -->|End of Loop| G[TvTerm]
     G -->|Success| H[Test case pass]
     G -->|Failure| G1[Test case fail]
+```
 
 
-
-###Test 31
+### Test 31
 
 |Title|Details|
 |--|--|

--- a/docs/pages/tvSettings_L2_Low-Level_TestSpecification.md
+++ b/docs/pages/tvSettings_L2_Low-Level_TestSpecification.md
@@ -353,9 +353,9 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set the Backlight Fade using SetBacklightFade() | from = 50, to = 100, duration = 5000 | tvERROR_NONE | Should be successful |
+| 02 | Set the Backlight Fade using SetBacklightFade() with 4 different values | from = random value(0-100), to = random value(0-100) , duration = random value(0-10000) | tvERROR_NONE | Should be successful |
 | 03 | Get the current Backlight Fade using GetCurrentBacklightFade() | get_from, get_to, get_current | tvERROR_NONE | Should be successful |
-| 04 | Validate the set and get values of from and to | from = 50, to = 100 | from = get_from, to = get_to | Should be successful |
+| 04 | Validate the set and get values of from , to, duration |  | from = get_from, to = get_to, duration = get_current | Should be successful |
 | 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
@@ -437,7 +437,7 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set current backlight mode using SetCurrentBacklightMode() | setMode = tvBacklightMode_MANUAL | tvERROR_NONE | Should be successful |
+| 02 | Set current backlight mode using SetCurrentBacklightMode() | setMode = tvBacklightMode_NONE to tvBacklightMode_MAX-1 | tvERROR_NONE | Should be successful |
 | 03 | Get current backlight mode using GetCurrentBacklightMode() | getMode = valid buffer | tvERROR_NONE | Should be successful |
 | 04 | Validate the set and get backlight modes are same | setMode, getMode | setMode should be equal to getMode | Should be successful |
 | 05 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
@@ -522,21 +522,15 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
-| 02 | Set the TV Dimming mode to "local" using SetTVDimmingMode | dimmingMode = "local" | tvERROR_NONE | Should be successful |
+| 02 | Set the TV Dimming mode to "local" using SetTVDimmingMode | dimmingMode = "local","fixed","global" | tvERROR_NONE | Should be successful |
 | 03 | Get the TV Dimming mode using GetTVDimmingMode | getDimmingMode = valid buffer | tvERROR_NONE | Should be successful |
-| 04 | Verify the set and get Dimming mode are same | getDimmingMode = "local" | "local" | Should be successful |
-| 05 | Set the TV Dimming mode to "fixed" using SetTVDimmingMode | dimmingMode = "fixed" | tvERROR_NONE | Should be successful |
-| 06 | Get the TV Dimming mode using GetTVDimmingMode | getDimmingMode = valid buffer | tvERROR_NONE | Should be successful |
-| 07 | Verify the set and get Dimming mode are same | getDimmingMode = "fixed" | "fixed" | Should be successful |
-| 08 | Set the TV Dimming mode to "global" using SetTVDimmingMode | dimmingMode = "global" | tvERROR_NONE | Should be successful |
-| 09 | Get the TV Dimming mode using GetTVDimmingMode | getDimmingMode = valid buffer | tvERROR_NONE | Should be successful |
-| 10 | Verify the set and get Dimming mode are same | getDimmingMode = "global" | "global" | Should be successful |
-| 11 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+| 04 | Verify the set and get Dimming mode are same |  | getDimmingMode = dimmingMode  | Should be successful |
+| 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit API Call] -->|Success| B[SetTVDimmingMode API Call with <br> values 'local, fixed, global']
+A[TvInit API Call] -->|Success| B[SetTVDimmingMode API Call with <br> values 'local', 'fixed', 'global']
 A -->|Failure| A1[Test Case Fail]
 B -->|Success| D[GetTVDimmingMode API Call]
 B -->|Failure| B1[Test Case Fail]
@@ -616,27 +610,22 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
-| 02 | Set the brightness using SetBrightness | brightness = 50 | tvERROR_NONE | Should be successful |
+| 02 | Set the brightness using SetBrightness for 4 different values | brightness = random(0-100) | tvERROR_NONE | Should be successful |
 | 03 | Get the brightness using GetBrightness | get_brightness = valid buffer | tvERROR_NONE | Should be successful |
-| 04 | Validate the set and get brightness values are equal | brightness = 50, get_brightness = 50 | Equal | Should be successful |
+| 04 | Validate the set and get brightness values are equal | brightness = get_brightness  | Equal | Should be successful |
 | 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    Start(Start) --> Step1[Call TvInit API]
-    Step1 -->|tvERROR_NONE| Step2[Call SetBrightness API with valid value]
-    Step1 -->|Failure| Fail1[Test Case Failed: TvInit API failed]
-    Step2 -->|tvERROR_NONE| Step3[Verify SetBrightness returns tvERROR_NONE]
-    Step2 -->|Failure| Fail2[Test Case Failed: SetBrightness API failed]
-    Step3 -->|Success| Step4[Call GetBrightness API]
-    Step3 -->|Failure| Fail3[Test Case Failed: SetBrightness return value verification failed]
-    Step4 -->|tvERROR_NONE| Step5[Verify GetBrightness returns tvERROR_NONE and value matches]
-    Step4 -->|Failure| Fail4[Test Case Failed: GetBrightness API failed]
-    Step5 -->|Success| Step6[Call TvTerm API]
-    Step5 -->|Failure| Fail5[Test Case Failed: GetBrightness return value verification failed]
+    Step1[Call TvInit API]-->|tvERROR_NONE| Step3{Iterate for 4 valid <br> brightness values }
+    Step3 -->Step2[Call SetBrightness API]
+    Step1 -->|Failure| Fail1[Test Case Failed]
+    Step2 -->|tvERROR_NONE| Step4[Call GetBrightness API]
+    Step4 -->|tvERROR_NONE,<br> get and set matches| Step3
+    Step3 -->|End of loop| Step6[Call TvTerm API]
     Step6 -->|tvERROR_NONE| End[Test Case Passed]
-    Step6 -->|Failure| Fail6[Test Case Failed: TvTerm API failed]
+    Step6 -->|Failure| Fail6[Test Case Failed]
 ```
 
 
@@ -664,20 +653,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set the contrast using SetContrast() | contrast = 50 | tvERROR_NONE | Should be successful |
+| 02 | Set the contrast using SetContrast() for 4 different values | contrast =  random(0-100) | tvERROR_NONE | Should be successful |
 | 03 | Get the contrast using GetContrast() | getContrast = valid buffer | tvERROR_NONE | Should be successful |
-| 04 | Check if the set and get contrast values match | contrast = 50, getContrast = retrieved value | tvERROR_NONE, getContrast = contrast | Should be successful |
+| 04 | Check if the set and get contrast values match |  |  getContrast = contrast | Should be successful |
 | 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit API Call] -->|tvERROR_NONE| B[SetContrast API Call]
+A[TvInit API Call] -->|tvERROR_NONE| Step1{Iterate for 4 valid <br> contrast values }
+Step1 --> B[SetContrast API Call]
 A -->|Failure| A1[Test case fail]
 B -->|tvERROR_NONE| C[GetContrast API Call]
-B -->|Failure| B1[Test case fail]
-C -->|tvERROR_NONE and Contrast value matches| D[TvTerm API Call]
-C -->|Failure| C1[Test case fail]
+C -->|tvERROR_NONE and Contrast value matches| Step1
+B -->|End of loop|D[TvTerm API Call]
 D -->|tvERROR_NONE| E[Test case success]
 D -->|Failure| D1[Test case fail]
 ```
@@ -707,28 +696,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set the sharpness using SetSharpness() | setSharpness = 50 | tvERROR_NONE | Should be successful |
-| 03 | If SetSharpness() fails, terminate the TV using TvTerm() and exit the test | None | None | Should fail |
-| 04 | Get the sharpness using GetSharpness() | getSharpness = 0 | tvERROR_NONE | Should be successful |
-| 05 | If GetSharpness() fails, terminate the TV using TvTerm() and exit the test | None | None | Should fail |
-| 06 | Assert that the set sharpness and the retrieved sharpness are equal | setSharpness = 50, getSharpness = 50 | True | Should be successful |
-| 07 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the sharpness using SetSharpness() for 4 different values | setSharpness = random(0-100) | tvERROR_NONE | Should be successful |
+| 03 | Get the sharpness using GetSharpness() | getSharpness = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Assert that the set sharpness and the retrieved sharpness are equal |  | setSharpness = getSharpness | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit()] -->|Success| B[SetSharpness()]
+A[TvInit] -->|Success| Loop{Iterate for 4 valid <br> Sharpness values}
+Loop --> B[SetSharpness]
 A -->|Failure| A1[Test case fail]
-B -->|Success| C[Verify SetSharpness() return status]
-B -->|Failure| B1[Test case fail]
-C -->|Success| D[GetSharpness()]
-C -->|Failure| C1[Test case fail]
-D -->|Success| E[Verify GetSharpness() return status]
-D -->|Failure| D1[Test case fail]
-E -->|Success| F[Verify sharpness value]
-E -->|Failure| E1[Test case fail]
-F -->|Success| G[TvTerm()]
-F -->|Failure| F1[Test case fail]
+B -->|Success| D[GetSharpness]
+D -->|Success, <br> get and set matches| Loop
+Loop -->|Success| G[TvTerm]
 G -->|Success| H[Test case success]
 G -->|Failure| G1[Test case fail]
 ```
@@ -758,24 +739,22 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set the saturation value using SetSaturation() | saturation_set = 50 | tvERROR_NONE | Should be successful |
-| 03 | Get the saturation value using GetSaturation() | saturation_get = address of variable | tvERROR_NONE | Should be successful |
-| 04 | Compare the set and get saturation values | saturation_set, saturation_get | saturation_set should be equal to saturation_get | Should be successful |
+| 02 | Set the saturation value using SetSaturation() for 4 different values| saturation_set = random(0-100) | tvERROR_NONE | Should be successful |
+| 03 | Get the saturation value using GetSaturation() | saturation_get = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Compare the set and get saturation values | | saturation_set = saturation_get | Should be successful |
 | 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit] -->|Success| B[SetSaturation]
-A -->|Failure| A1[Test case fail: TvInit]
-B -->|Success| C[GetSaturation]
-B -->|Failure| B1[Test case fail: SetSaturation]
-C -->|Success| D[Compare Saturation Value]
-C -->|Failure| C1[Test case fail: GetSaturation]
-D -->|Success| E[TvTerm]
-D -->|Failure| D1[Test case fail: Compare Saturation Value]
-E -->|Success| F[Test case pass]
-E -->|Failure| E1[Test case fail: TvTerm]
+A[TvInit] -->|Success| Loop{Iterate for 4 valid <br> Saturation values}
+Loop --> B[SetSaturation]
+A -->|Failure| A1[Test case fail]
+B -->|Success| D[GetSaturation]
+D -->|Success, <br> get and set matches| Loop
+Loop -->|Success| G[TvTerm]
+G -->|Success| H[Test case success]
+G -->|Failure| G1[Test case fail]
 ```
 
 
@@ -803,20 +782,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
-| 02 | Set the Hue using SetHue | hue = 50 | tvERROR_NONE | Should be successful |
+| 02 | Set the Hue using SetHue for 4 different values| hue = random(0-100) | tvERROR_NONE | Should be successful |
 | 03 | Get the Hue using GetHue | getHue = valid buffer | tvERROR_NONE | Should be successful |
-| 04 | Validate the set and get Hue values are same | hue = 50, getHue = retrieved value | hue should be equal to getHue | Should be successful |
+| 04 | Validate the set and get Hue values are same | | hue = getHue  | Should be successful |
 | 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|tvERROR_NONE| B[SetHue]
+    A[TvInit] -->|tvERROR_NONE| Loop{Iterate for 4 valid <br> Hue values}
+    Loop --> B[SetHue]
     A -->|Failure| A1[Test case fail]
     B -->|tvERROR_NONE| C[GetHue]
-    B -->|Failure| B1[Test case fail]
-    C -->|tvERROR_NONE and hue value matches| D[TvTerm]
-    C -->|Failure| C1[Test case fail]
+    C -->|tvERROR_NONE <br> hue value matches| Loop
+    Loop -->|End of loop|D[TvTerm]
     D -->|tvERROR_NONE| E[Test case success]
     D -->|Failure| D1[Test case fail]
 ```
@@ -846,23 +825,19 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
-| 02 | Set the color temperature using SetColorTemperature | colorTemp = tvColorTemp_STANDARD | tvERROR_NONE | Should be successful |
-| 03 | Get the color temperature using GetColorTemperature | getColorTemp = valid buffer | tvERROR_NONE, colorTemp = getColorTemp | Should be successful |
+| 02 | Set various color temperatures using SetColorTemperature | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX-1 | tvERROR_NONE | Should be successful |
+| 03 | Get the color temperature using GetColorTemperature and verify get and set | getColorTemp = valid buffer | tvERROR_NONE, colorTemp = getColorTemp | Should be successful |
 | 04 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit API Call] -->|Success| B[SetColorTemperature API Call]
+    A[TvInit API Call] -->|Success| Loop{Iterate through various <br> Color temperature}
+    Loop -->B[SetColorTemperature API Call]
     A -->|Failure| A1[Test case fail]
-    B -->|Success| C[Verify SetColorTemperature API returns tvERROR_NONE]
-    B -->|Failure| B1[Test case fail]
-    C -->|Success| D[GetColorTemperature API Call]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E[Verify GetColorTemperature API returns tvERROR_NONE and value matches]
-    D -->|Failure| D1[Test case fail]
-    E -->|Success| F[TvTerm API Call]
-    E -->|Failure| E1[Test case fail]
+    B -->|Success| D[GetColorTemperature API Call]
+    D -->| Success <br> Get and set matches|Loop
+    Loop -->|End of loop| F[TvTerm API Call]
     F -->|Success| G[Test case success]
     F -->|Failure| F1[Test case fail]
 ```
@@ -892,24 +867,22 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set the Aspect Ratio using SetAspectRatio() with tvDisplayMode_4x3 | setMode = tvDisplayMode_4x3 | tvERROR_NONE | Should be successful |
+| 02 | Set the Aspect Ratio using SetAspectRatio() for various aspect ratios| setMode = tvDisplayMode_4x3 to tvDisplayMode_MAX-1| tvERROR_NONE | Should be successful |
 | 03 | Get the Aspect Ratio using GetAspectRatio() | getMode = valid buffer | tvERROR_NONE | Should be successful |
-| 04 | Validate the set and get Aspect Ratio are same | setMode, getMode | setMode should be equal to getMode | Should be successful |
+| 04 | Validate the set and get Aspect Ratio are same |  | setMode=getMode | Should be successful |
 | 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B[SetAspectRatio]
-    A -->|Failure| A1[Test case fail: TvInit failed]
+    A[TvInit] -->|Success| Loop{Iterate through various <br> aspect ratio}
+    Loop --> B[SetAspectRatio]
+    A -->|Failure| A1[Test case fail]
     B -->|Success| C[GetAspectRatio]
-    B -->|Failure| B1[Test case fail: SetAspectRatio failed]
-    C -->|Success| D[Verify GetAspectRatio value]
-    C -->|Failure| C1[Test case fail: GetAspectRatio failed]
-    D -->|Success| E[TvTerm]
-    D -->|Failure| D1[Test case fail: GetAspectRatio value mismatch]
+    C -->|Success <br> get and set matches| Loop
+    Loop -->|End of loop|E[TvTerm]
     E -->|Success| F[Test case pass]
-    E -->|Failure| E1[Test case fail: TvTerm failed]
+    E -->|Failure| E1[Test case fail]
 ```
 
 
@@ -938,25 +911,26 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
 | 02 | Set Low Latency State to 1 using SetLowLatencyState(1) | LowLatencyState = 1 | tvERROR_NONE | Should be successful |
-| 03 | Get Low Latency State using GetLowLatencyState(&lowlatencystate) | lowlatencystate = address of integer variable | tvERROR_NONE, lowlatencystate = 1 | Should be successful |
+| 03 | Get Low Latency State using GetLowLatencyState() and verify the value| lowlatencystate = valid buffer | tvERROR_NONE, lowlatencystate = 1 | Should be successful |
 | 04 | Set Low Latency State to 0 using SetLowLatencyState(0) | LowLatencyState = 0 | tvERROR_NONE | Should be successful |
-| 05 | Get Low Latency State using GetLowLatencyState(&lowlatencystate) | lowlatencystate = address of integer variable | tvERROR_NONE, lowlatencystate = 0 | Should be successful |
+| 05 | Get Low Latency State using GetLowLatencyState() and verify the value| lowlatencystate = valid buffer | tvERROR_NONE, lowlatencystate = 0 | Should be successful |
 | 06 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit()] -->|tvERROR_NONE| B[SetLowLatencyState(1)]
-B -->|tvERROR_NONE| C[GetLowLatencyState(&lowlatencystate)]
-C -->|tvERROR_NONE, lowlatencystate=1| D[SetLowLatencyState(0)]
-D -->|tvERROR_NONE| E[GetLowLatencyState(&lowlatencystate)]
-E -->|tvERROR_NONE, lowlatencystate=0| F[TvTerm()]
-A -->|Failure| G[Test case fail]
-B -->|Failure| H[Test case fail]
-C -->|Failure| I[Test case fail]
-D -->|Failure| J[Test case fail]
-E -->|Failure| K[Test case fail]
-F -->|Failure| L[Test case fail]
+A[TvInit] -->|tvERROR_NONE| B[SetLowLatencyState with value 1]
+B -->|tvERROR_NONE| C[GetLowLatencyState]
+C -->|tvERROR_NONE <br> lowlatencystate=1| D[SetLowLatencyState with value 0]
+D -->|tvERROR_NONE| E[GetLowLatencyState]
+E -->|tvERROR_NONE <br> lowlatencystate=0| F[TvTerm]
+F -->|tvERROR_NONE| G[Test case success]
+A -->|Failure| A1[Test case fail]
+B -->|Failure| B1[Test case fail]
+C -->|Failure| C1[Test case fail]
+D -->|Failure| D1[Test case fail]
+E -->|Failure| E1[Test case fail]
+F -->|Failure| F1[Test case fail]
 ```
 
 
@@ -985,25 +959,26 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
 | 02 | Set Dynamic Contrast to enabled using SetDynamicContrast | dynamicContrastEnable = "enabled" | tvERROR_NONE | Should be successful |
-| 03 | Get the Dynamic Contrast status using GetDynamicContrast | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, isDynamicContrastEnabled = "enabled" | Should be successful |
+| 03 | Get the Dynamic Contrast status using GetDynamicContrast and verify| isDynamicContrastEnabled = valid buffer | tvERROR_NONE, isDynamicContrastEnabled = "enabled" | Should be successful |
 | 04 | Set Dynamic Contrast to disabled using SetDynamicContrast | dynamicContrastEnable = "disabled" | tvERROR_NONE | Should be successful |
-| 05 | Get the Dynamic Contrast status using GetDynamicContrast | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, isDynamicContrastEnabled = "disabled" | Should be successful |
+| 05 | Get the Dynamic Contrast status using GetDynamicContrast and verify | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, isDynamicContrastEnabled = "disabled" | Should be successful |
 | 06 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit()] -->|tvERROR_NONE| B[SetDynamicContrast(enabled)]
-B -->|tvERROR_NONE| C[GetDynamicContrast()]
-C -->|tvERROR_NONE, isDynamicContrastEnabled = enabled| D[SetDynamicContrast(disabled)]
-D -->|tvERROR_NONE| E[GetDynamicContrast()]
-E -->|tvERROR_NONE, isDynamicContrastEnabled = disabled| F[TvTerm()]
-A -->|Failure| G[Test case fail]
-B -->|Failure| H[Test case fail]
-C -->|Failure| I[Test case fail]
-D -->|Failure| J[Test case fail]
-E -->|Failure| K[Test case fail]
-F -->|Failure| L[Test case fail]
+A[TvInit] -->|tvERROR_NONE| B[SetDynamicContrast <br> with value 'enabled']
+B -->|tvERROR_NONE| C[GetDynamicContrast]
+C -->|tvERROR_NONE <br> isDynamicContrastEnabled = 'enabled'| D[SetDynamicContrast <br> with value 'disabled']
+D -->|tvERROR_NONE| E[GetDynamicContrast]
+E -->|tvERROR_NONE <br> isDynamicContrastEnabled = 'disabled'| F[TvTerm]
+F --> |tvERROR_NONE| G[Test case success]
+A -->|Failure| A1[Test case fail]
+B -->|Failure| B1[Test case fail]
+C -->|Failure| C1[Test case fail]
+D -->|Failure| D1[Test case fail]
+E -->|Failure| E1[Test case fail]
+F -->|Failure| F1[Test case fail]
 ```
 
 
@@ -1032,23 +1007,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set the Dynamic Gamma using SetDynamicGamma() | setGammaValue = 2.0 | tvERROR_NONE | Should be successful |
-| 03 | If SetDynamicGamma() fails, terminate the TV using TvTerm() and return | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Dynamic Gamma using SetDynamicGamma() for different valid values| setGammaValue = 1.80 to 2.6 | tvERROR_NONE | Should be successful |
 | 04 | Get the Dynamic Gamma using GetDynamicGamma() | getGammaValue = valid buffer | tvERROR_NONE | Should be successful |
-| 05 | Assert that the set and get Gamma values are equal | setGammaValue = 2.0, getGammaValue = retrieved value | setGammaValue should be equal to getGammaValue | Should be successful |
+| 05 | Assert that the set and get Gamma values are equal |  | setGammaValue = getGammaValue | Should be successful |
 | 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B[SetDynamicGamma]
+    A[TvInit] -->|Success| Loop{Iterate through <br> valid values}
+    Loop --> B[SetDynamicGamma]
     A -->|Failure| A1[Test case fail]
     B -->|Success| C[GetDynamicGamma]
-    B -->|Failure| B1[Test case fail]
-    C -->|Success| D[Compare GetDynamicGamma value with SetDynamicGamma value]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E[TvTerm]
-    D -->|Failure| D1[Test case fail]
+    C -->|Success <br> get and set matches| Loop
+    Loop --> |End of loop|E[TvTerm]
     E -->|Success| F[Test case success]
     E -->|Failure| E1[Test case fail]
 ```
@@ -1080,7 +1052,7 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | 01 | Initialize TV using TvInit | None | tvERROR_NONE | Should be successful |
 | 02 | Invoke GetTVSupportedDolbyVisionModes with valid dvModes and count | dvModes = valid buffer, count = valid buffer | tvERROR_NONE | Should be successful |
 | 03 | Check if the count of supported Dolby Vision modes is between 0 and tvMode_Max | count = returned value from GetTVSupportedDolbyVisionModes | count >= 0 and count <= tvMode_Max | Should be successful |
-| 04 | Loop through the indices and compare the test results with the platform-supported configurations file using the path 'DolbyVisionMode/index' | dvModes[i] = returned value from GetTVSupportedDolbyVisionModes | Equal to the value in the platform-supported configurations file | Should be successful |
+| 04 | Loop through the indices and compare the test results with the platform-supported configurations file using the path 'DolbyVisionMode/index' | dvModes[i] = returned value from GetTVSupportedDolbyVisionModes |  dvModes = value in the platform-supported configurations file | Should be successful |
 | 05 | Terminate TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
@@ -1088,11 +1060,10 @@ If user chose to run the test in interactive mode, then the test case has to be 
 graph TB
 A[TvInit API Call] -->|tvERROR_NONE| B[GetTVSupportedDolbyVisionModes API Call]
 A -->|Failure| A1[Test case fail]
-B -->|tvERROR_NONE| C[Verify count of supported Dolby Vision modes]
+B -->|tvERROR_NONE| D[Loop through array of supported Dolby Vision modes]
 B -->|Failure| B1[Test case fail]
-C -->|0 <= count <= tvMode_Max| D[Loop through array of supported Dolby Vision modes]
-C -->|Failure| C1[Test case fail]
-D --> E[TvTerm API Call]
+D -->|Success| E[TvTerm API Call]
+D -->|Failure| D1[Test case fail]
 E -->|tvERROR_NONE| F[Test case success]
 E -->|Failure| E1[Test case fail]
 ```
@@ -1122,22 +1093,19 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
-| 02 | Set the TV Dolby Vision mode using SetTVDolbyVisionMode | dolbyMode = tvDolbyMode_Dark | tvERROR_NONE | Should be successful |
-| 03 | Get the TV Dolby Vision mode using GetTVDolbyVisionMode | getDolbyMode = valid buffer | tvERROR_NONE, getDolbyMode = dolbyMode | Should be successful |
-| 04 | If there is a mismatch in set and get Dolby Vision Mode, terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
-| 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+| 02 | Set the TV Dolby Vision mode using SetTVDolbyVisionMode | dolbyMode = tvDolbyMode_Dark to tvHLGMode_Reserved3 | tvERROR_NONE | Should be successful |
+| 03 | Get the TV Dolby Vision mode using GetTVDolbyVisionMode and verify | getDolbyMode = valid buffer | tvERROR_NONE, getDolbyMode = dolbyMode | Should be successful |
+| 04 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit()] -->|tvERROR_NONE| B[SetTVDolbyVisionMode()]
+A[TvInit] -->|tvERROR_NONE| Loop{Iterate through supported <br> Dolby Vision Modes }
+Loop --> B[SetTVDolbyVisionMode]
 A -->|Failure| A1[Test case fail]
-B -->|tvERROR_NONE| C[GetTVDolbyVisionMode()]
-B -->|Failure| B1[Test case fail]
-C -->|tvERROR_NONE| D[Verify dolbyMode]
-C -->|Failure| C1[Test case fail]
-D -->|Match| E[TvTerm()]
-D -->|Mismatch| D1[Test case fail]
+B -->|tvERROR_NONE| C[GetTVDolbyVisionMode]
+C -->|tvERROR_NONE <br> get and set matches| Loop
+Loop -->|End of loop| E[TvTerm]
 E -->|tvERROR_NONE| F[Test case pass]
 E -->|Failure| E1[Test case fail]
 ```
@@ -1167,22 +1135,18 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize TV using TvInit | No input parameters | tvERROR_NONE | Should be successful |
-| 02 | Get supported picture modes and their count using GetTVSupportedPictureModes | pictureModes = valid buffer, count = valid buffer | status not equal to tvERROR_INVALID_PARAM and tvERROR_INVALID_STATE, count between 1 and PIC_MODES_SUPPORTED_MAX | Should be successful |
-| 03 | Loop through the picture modes and compare with the platform-supported configurations file | pictureModes[i]->name = "PictureMode/index" | Equal to profile string | Should be successful |
+| 02 | Get supported picture modes and their count using GetTVSupportedPictureModes | pictureModes = valid buffer, count = valid buffer | tvERROR_NONE, count = 1-PIC_MODES_SUPPORTED_MAX | Should be successful |
+| 03 | Loop through the picture modes and compare with the platform-supported configurations file | pictureModes[i]->name = "PictureMode/index" | value matches | Should be successful |
 | 04 | Terminate TV using TvTerm | No input parameters | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit()] -->|tvERROR_NONE| B[GetTVSupportedPictureModes()]
+    A[TvInit] -->|tvERROR_NONE| B[GetTVSupportedPictureModes]
     A -->|!= tvERROR_NONE| C[Test case fail]
-    B -->|!= tvERROR_INVALID_PARAM, != tvERROR_INVALID_STATE| D[Check count of picture modes]
-    B -->|== tvERROR_INVALID_PARAM or == tvERROR_INVALID_STATE| E[Test case fail]
-    D -->|1 <= count <= PIC_MODES_SUPPORTED_MAX| F[Compare picture modes with Sink-4K-TvSettings.yaml]
-    D -->|count < 1 or count > PIC_MODES_SUPPORTED_MAX| G[Test case fail]
-    F -->|Match| H[Loop through picture modes]
-    F -->|No Match| I[Test case fail]
-    H --> J[TvTerm()]
+    B -->|= tvERROR_NONE <br> 1 <= count <= PIC_MODES_SUPPORTED_MAX| F[Loop and compare <br> with profile picture modes]
+    B -->|!= tvERROR_NONE| G[Test case fail]
+    F -->|Match| J[TvTerm]
     J -->|tvERROR_NONE| K[Test case pass]
     J -->|!= tvERROR_NONE| L[Test case fail]
 ```
@@ -1215,27 +1179,21 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | 02 | Get supported picture modes using GetTVSupportedPictureModes() | pictureModes = valid buffer, count = valid buffer | tvERROR_NONE | Should be successful |
 | 03 | Set TV picture mode using SetTVPictureMode() for each supported mode | pictureMode = pictureModes[i]->name | tvERROR_NONE | Should be successful |
 | 04 | Get TV picture mode using GetTVPictureMode() after setting each mode | pictureMode = valid buffer | tvERROR_NONE | Should be successful |
-| 05 | Validate the set and get picture modes are same | pictureModes[i]->name, pictureMode | Equal | Should be successful |
+| 05 | Validate the set and get picture modes are same | |  pictureModes[i]->name = pictureMode | Should be successful |
 | 06 | Terminate TV using TvTerm() after each set and get operation | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit()] -->|tvERROR_NONE| B[Declare pic_modes_t array and unsigned short variable]
-B -->|tvERROR_NONE| C[GetTVSupportedPictureModes()]
-C -->|tvERROR_NONE, 1 <= count <= PIC_MODES_SUPPORTED_MAX| D[Choose a valid picture mode]
-D -->|Valid picture mode chosen| E[SetTVPictureMode()]
-E -->|tvERROR_NONE| F[Declare char array of size PIC_MODE_NAME_MAX]
-F -->|Array declared| G[GetTVPictureMode()]
-G -->|tvERROR_NONE, returned picture mode matches set picture mode| H[TvTerm()]
+A[TvInit] -->|tvERROR_NONE| C[GetTVSupportedPictureModes]
+C -->|tvERROR_NONE <br> 1 <= count <= PIC_MODES_SUPPORTED_MAX| E[SetTVPictureMode]
+E -->|tvERROR_NONE| G[GetTVPictureMode]
+G -->|tvERROR_NONE <br> picture mode matches set picture mode| H[TvTerm]
 H -->|tvERROR_NONE| I[Test case pass]
 A -->|!=tvERROR_NONE| J[Test case fail]
-B -->|!=tvERROR_NONE| K[Test case fail]
-C -->|!=tvERROR_NONE or count < 1 or count > PIC_MODES_SUPPORTED_MAX| L[Test case fail]
-D -->|Invalid picture mode chosen| M[Test case fail]
+C -->|!=tvERROR_NONE| L[Test case fail]
 E -->|!=tvERROR_NONE| N[Test case fail]
-F -->|Array declaration failed| O[Test case fail]
-G -->|!=tvERROR_NONE or returned picture mode doesn't match set picture mode| P[Test case fail]
+G -->|!=tvERROR_NONE | P[Test case fail]
 H -->|!=tvERROR_NONE| Q[Test case fail]
 ```
 
@@ -1266,24 +1224,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
 | 02 | Loop through different color temperatures and source ids | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX, sourceId = ALL_SRC_OFFSET to MAX_OFFSET | None | None |
-| 03 | Set the color Temperature Rgain on Source using SetColorTemp_Rgain_onSource | colorTemp = current colorTemp, setRgain = 0 to 2047, sourceId = current sourceId, saveOnly = 0 | tvERROR_NONE | Should be successful |
-| 04 | Get the color Temperature Rgain on Source using GetColorTemp_Rgain_onSource | colorTemp = current colorTemp, rgain = address of rgain, sourceId = current sourceId | tvERROR_NONE | Should be successful |
-| 05 | Check if the retrieved rgain matches the set rgain | rgain = retrieved rgain, setRgain = set rgain | rgain should be equal to setRgain | Should be successful |
+| 03 | Set the color Temperature Rgain on Source using SetColorTemp_Rgain_onSource | colorTemp = current colorTemp, setRgain = 0 to 2047, sourceId = current sourceId, saveOnly = 0 to 1| tvERROR_NONE | Should be successful |
+| 04 | Get the color Temperature Rgain on Source using GetColorTemp_Rgain_onSource |  colorTemp = current colorTemp, sourceId = current sourceId | tvERROR_NONE | Should be successful |
+| 05 | Check if the retrieved rgain matches the set rgain | | rgain = setRgain | Should be successful |
 | 06 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A[TvInit] -->|Success| B{Loop through color <br> temperatures, source ids,<br>rgain,saveonly}
     A -->|Failure| A1[Test case fail]
-    B -->|Next Combination| C[SetColorTemp_Rgain_onSource with rgain value and saveOnly parameter as 0]
-    B -->|End of Loop| G[TvTerm]
+    B --> C[SetColorTemp_Rgain_onSource <br> with valid values]
     C -->|Success| D[GetColorTemp_Rgain_onSource]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E{Verify rgain value}
-    D -->|Failure| D1[Test case fail]
-    E -->|Match| B
-    E -->|Mismatch| E1[Test case fail]
+    D -->|Success, <br> set get rgain matches| B
+    B -->|End of Loop| G[TvTerm]
     G -->|Success| H[Test case pass]
     G -->|Failure| G1[Test case fail]
 ```
@@ -1315,24 +1269,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
 | 02 | Loop through different color temperatures and source ids | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX, sourceId = ALL_SRC_OFFSET to MAX_OFFSET | None | Should be successful |
-| 03 | Set the color Temperature Ggain on Source using SetColorTemp_Ggain_onSource | colorTemp = current colorTemp, set_ggain = 0 to 2047, sourceId = current sourceId, saveOnly = 0 | tvERROR_NONE | Should be successful |
+| 03 | Set the color Temperature Ggain on Source using SetColorTemp_Ggain_onSource | colorTemp = current colorTemp, set_ggain = 0 to 2047, sourceId = current sourceId, saveOnly = 0 to 1 | tvERROR_NONE | Should be successful |
 | 04 | Get the color Temperature Ggain on Source using GetColorTemp_Ggain_onSource | colorTemp = current colorTemp, ggain = address of ggain, sourceId = current sourceId | tvERROR_NONE | Should be successful |
-| 05 | Check if the retrieved ggain matches the set ggain | ggain = retrieved ggain, set_ggain = set ggain | ggain should be equal to set_ggain | Should be successful |
+| 05 | Check if the retrieved ggain matches the set ggain | |  ggain = set_ggain  | Should be successful |
 | 06 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A[TvInit] -->|Success| B{Loop through color <br> temperatures, source ids,<br>ggain,saveonly}
     A -->|Failure| A1[Test case fail]
-    B -->|Next Combination| C[SetColorTemp_Ggain_onSource with ggain value and saveOnly parameter as 0]
-    B -->|End of Loop| G[TvTerm]
+    B --> C[SetColorTemp_Ggain_onSource <br> with valid values]
     C -->|Success| D[GetColorTemp_Ggain_onSource]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E{Verify ggain value}
-    D -->|Failure| D1[Test case fail]
-    E -->|Match| B
-    E -->|Mismatch| E1[Test case fail]
+    D -->|Success, <br> set get ggain matches| B
+    B -->|End of Loop| G[TvTerm]
     G -->|Success| H[Test case pass]
     G -->|Failure| G1[Test case fail]
 ```
@@ -1363,27 +1313,22 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
 | 02 | Loop through different color temperatures and source ids | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX, sourceId = ALL_SRC_OFFSET to MAX_OFFSET | None | Should be successful |
-| 03 | Set the color Temperature Bgain on Source using SetColorTemp_Bgain_onSource | colorTemp, bgain = 0 to 2047, sourceId, saveOnly = 0 | tvERROR_NONE | Should be successful |
+| 03 | Set the color Temperature Bgain on Source using SetColorTemp_Bgain_onSource | colorTemp, bgain = 0 to 2047, sourceId, saveOnly = 0 to 1 | tvERROR_NONE | Should be successful |
 | 04 | Get the color Temperature Bgain on Source using GetColorTemp_Bgain_onSource | colorTemp, &get_bgain, sourceId | tvERROR_NONE | Should be successful |
-| 05 | Check if the retrieved value matches the set value | bgain, get_bgain | bgain should be equal to get_bgain | Should be successful |
+| 05 | Check if the retrieved value matches the set value | | bgain = get_bgain | Should be successful |
 | 06 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A[TvInit] -->|Success| B{Loop through color <br> temperatures, source ids,<br>bgain,saveonly}
     A -->|Failure| A1[Test case fail]
-    B -->|Next Combination| C[SetColorTemp_Bgain_onSource]
-    B -->|All Combinations Done| G[TvTerm]
+    B --> C[SetColorTemp_Bgain_onSource <br> with valid values]
     C -->|Success| D[GetColorTemp_Bgain_onSource]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E{Verify bgain value}
-    D -->|Failure| D1[Test case fail]
-    E -->|Match| B
-    E -->|Mismatch| E1[Test case fail]
+    D -->|Success, <br> set get bgain matches| B
+    B -->|End of Loop| G[TvTerm]
     G -->|Success| H[Test case pass]
     G -->|Failure| G1[Test case fail]
-```
 
 
 
@@ -1413,31 +1358,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
 | 02 | Loop through different color temperatures and source ids. Set the color Temperature R post offset on Source using SetColorTemp_R_post_offset_onSource | colorTemp = value, rpostoffset_set = value, sourceId = value, saveOnly = value | tvERROR_NONE | Should be successful |
 | 03 | Get the color Temperature R post offset on Source using GetColorTemp_R_post_offset_onSource | colorTemp = value, sourceId = value | tvERROR_NONE | Should be successful |
-| 04 | Check if the retrieved value matches the set value | rpostoffset_set = value, rpostoffset_get = value | rpostoffset_set should be equal to rpostoffset_get | Should be successful |
+| 04 | Check if the retrieved value matches the set value | | rpostoffset_set = rpostoffset_get | Should be successful |
 | 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit()] -->|Success| B{Loop through color temperatures and source ids}
+    A[TvInit] -->|Success| B{Loop through color <br> temperatures, source ids,<br>rpostoffset,saveonly}
     A -->|Failure| A1[Test case fail]
-    B -->|Next Combination| C[SetColorTemp_R_post_offset_onSource() with saveOnly=0]
-    B -->|End of Loop| G[TvTerm()]
-    C -->|Success| D[GetColorTemp_R_post_offset_onSource()]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E{Compare set and retrieved rpostoffset values}
-    D -->|Failure| D1[Test case fail]
-    E -->|Match| B
-    E -->|Mismatch| E1[Test case fail]
+    B --> C[SetColorTemp_R_post_offset_onSource <br> with valid values]
+    C -->|Success| D[GetColorTemp_R_post_offset_onSource]
+    D -->|Success, <br> set get rpostoffset matches| B
+    B -->|End of Loop| G[TvTerm]
     G -->|Success| H[Test case pass]
     G -->|Failure| G1[Test case fail]
-    B --> F[SetColorTemp_R_post_offset_onSource() with saveOnly=1]
-    F -->|Success| I[GetColorTemp_R_post_offset_onSource()]
-    F -->|Failure| F1[Test case fail]
-    I -->|Success| J{Compare set and retrieved rpostoffset values}
-    I -->|Failure| I1[Test case fail]
-    J -->|Match| B
-    J -->|Mismatch| J1[Test case fail]
 ```
 
 
@@ -1466,21 +1400,19 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
 | 02 | Loop through different color temperatures and source ids | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX, sourceId = ALL_SRC_OFFSET to MAX_OFFSET | None | None |
-| 03 | Set the color Temperature G post offset on Source using SetColorTemp_G_post_offset_onSource() | colorTemp, gpostoffset_set = -1024 to 1023, sourceId, saveOnly = 0 | tvERROR_NONE | Should be successful |
-| 04 | Get the color Temperature G post offset on Source using GetColorTemp_G_post_offset_onSource() | colorTemp, &gpostoffset_get, sourceId | tvERROR_NONE, gpostoffset_set | Should be successful |
+| 03 | Set the color Temperature G post offset on Source using SetColorTemp_G_post_offset_onSource() | colorTemp, gpostoffset_set = -1024 to 1023, sourceId, saveOnly = 0 to 1 | tvERROR_NONE | Should be successful |
+| 04 | Get the color Temperature G post offset on Source using GetColorTemp_G_post_offset_onSource() and verify| colorTemp, &gpostoffset_get, sourceId | tvERROR_NONE, gpostoffset_set = gpostoffset_get | Should be successful |
 | 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A[TvInit] -->|Success| B{Loop through color <br> temperatures, source ids,<br>gpostoffset,saveonly}
     A -->|Failure| A1[Test case fail]
-    B -->|Next Combination| C[SetColorTemp_G_post_offset_onSource]
-    B -->|End of Loop| G[TvTerm]
+    B --> C[SetColorTemp_G_post_offset_onSource <br> with valid values]
     C -->|Success| D[GetColorTemp_G_post_offset_onSource]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| B
-    D -->|Failure| D1[Test case fail]
+    D -->|Success, <br> set get gpostoffset matches| B
+    B -->|End of Loop| G[TvTerm]
     G -->|Success| H[Test case pass]
     G -->|Failure| G1[Test case fail]
 ```
@@ -1510,24 +1442,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
-| 02 | Loop through different color temperatures and source ids. Set the color Temperature B post offset on Source using SetColorTemp_B_post_offset_onSource | colorTemp = value, bpostoffset_set = value, sourceId = value, saveOnly = 1 | tvERROR_NONE | Should be successful |
+| 02 | Loop through different color temperatures and source ids. Set the color Temperature B post offset on Source using SetColorTemp_B_post_offset_onSource | colorTemp = value, bpostoffset_set = value, sourceId = value, saveOnly = 0 to 1 | tvERROR_NONE | Should be successful |
 | 03 | Get the color Temperature B post offset on Source using GetColorTemp_B_post_offset_onSource | colorTemp = value, sourceId = value | tvERROR_NONE | Should be successful |
-| 04 | Check if the retrieved value matches the set value | bpostoffset_set = value, bpostoffset_get = value | bpostoffset_set should be equal to bpostoffset_get | Should be successful |
+| 04 | Check if the retrieved value matches the set value |  | bpostoffset_set = bpostoffset_get | Should be successful |
 | 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A[TvInit] -->|Success| B{Loop through color <br> temperatures, source ids,<br>bpostoffset,saveonly}
     A -->|Failure| A1[Test case fail]
-    B -->|Next Combination| C[SetColorTemp_B_post_offset_onSource]
-    B -->|End of Loop| G[TvTerm]
+    B --> C[SetColorTemp_B_post_offset_onSource <br> with valid values]
     C -->|Success| D[GetColorTemp_B_post_offset_onSource]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E{Compare set and retrieved bpostoffset}
-    D -->|Failure| D1[Test case fail]
-    E -->|Match| B
-    E -->|Mismatch| E1[Test case fail]
+    D -->|Success, <br> set get bpostoffset matches| B
+    B -->|End of Loop| G[TvTerm]
     G -->|Success| H[Test case pass]
     G -->|Failure| G1[Test case fail]
 ```
@@ -1559,20 +1487,19 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
 | 02 | Disable the WB Calibration Mode using EnableWBCalibrationMode() | false | tvERROR_NONE | Should be successful |
 | 03 | Get the current WB Calibration Mode using GetCurrentWBCalibrationMode() | &value | tvERROR_NONE, false | Should be successful |
-| 04 | If the status is not tvERROR_NONE or value is not false, terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+| 04 |Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    Start(Start) --> Step1
-    Step1{Call TvInit API} -->|tvERROR_NONE| Step2
-    Step1 -->|Failure| TestcaseFail1[Test case 34 failed]
-    Step2{Call EnableWBCalibrationMode API with false} -->|tvERROR_NONE| Step3
-    Step2 -->|Failure| TestcaseFail2[Test case 34 failed]
-    Step3{Call GetCurrentWBCalibrationMode API} -->|tvERROR_NONE and output is false| Step4
-    Step3 -->|Failure| TestcaseFail3[Test case 34 failed]
-    Step4{Call TvTerm API} -->|tvERROR_NONE| End(End)
-    Step4 -->|Failure| TestcaseFail4[Test case 34 failed]
+    Step1[Call TvInit API] -->|tvERROR_NONE| Step2
+    Step1 -->|Failure| Fail1[Test case failed]
+    Step2[Call EnableWBCalibrationMode API with false] -->|tvERROR_NONE| Step3
+    Step2 -->|Failure| Fail2[Test case  failed]
+    Step3[Call GetCurrentWBCalibrationMode API] -->|tvERROR_NONE and output is false| Step4
+    Step3 -->|Failure| Fail3[Test case 34 failed]
+    Step4[Call TvTerm API] -->|tvERROR_NONE| Step5[Testcase success]
+    Step4 -->|Failure| Fail4[Test case 34 failed]
 ```
 
 
@@ -1601,24 +1528,18 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
 | 02 | Enable WB Calibration Mode using EnableWBCalibrationMode() | value = true | tvERROR_NONE | Should be successful |
-| 03 | Get the current WB Calibration Mode using GetCurrentWBCalibrationMode() | value = address of bool variable | tvERROR_NONE, value = true | Should be successful |
-| 04 | Disable WB Calibration Mode using EnableWBCalibrationMode() | value = false | tvERROR_NONE | Should be successful |
-| 05 | Get the current WB Calibration Mode using GetCurrentWBCalibrationMode() | value = address of bool variable | tvERROR_NONE, value = false | Should be successful |
-| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+| 03 | Get the current WB Calibration Mode using GetCurrentWBCalibrationMode()  and verify| value = valid buffer| tvERROR_NONE, value = true | Should be successful |
+| 04 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit()] -->|tvERROR_NONE| B[EnableWBCalibrationMode(true)]
+    A[TvInit] -->|tvERROR_NONE| B[EnableWBCalibrationMode <br> with true]
     A -->|!=tvERROR_NONE| A1[Test case fail]
-    B -->|tvERROR_NONE| C[GetCurrentWBCalibrationMode()]
+    B -->|tvERROR_NONE| C[GetCurrentWBCalibrationMode]
     B -->|!=tvERROR_NONE| B1[Test case fail]
-    C -->|tvERROR_NONE, output=true| D[EnableWBCalibrationMode(false)]
-    C -->|!=tvERROR_NONE or output!=true| C1[Test case fail]
-    D -->|tvERROR_NONE| E[GetCurrentWBCalibrationMode()]
-    D -->|!=tvERROR_NONE| D1[Test case fail]
-    E -->|tvERROR_NONE, output=false| F[TvTerm()]
-    E -->|!=tvERROR_NONE or output!=false| E1[Test case fail]
+    C -->|tvERROR_NONE, output=true| F[TvTerm]
+    C -->|!=tvERROR_NONE| C1[Test case fail]
     F -->|tvERROR_NONE| G[Test case pass]
     F -->|!=tvERROR_NONE| F1[Test case fail]
 ```
@@ -1649,25 +1570,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set the Gamma Table using SetGammaTable() with valid buffers | pData_R = valid buffer, pData_G = valid buffer, pData_B = valid buffer, size = 256 | tvERROR_NONE | Should be successful |
-| 03 | If SetGammaTable() fails, terminate the TV using TvTerm() and return | None | None | Should fail |
-| 04 | Get the Gamma Table using GetGammaTable() with valid buffers | getData_R = valid buffer, getData_G = valid buffer, getData_B = valid buffer, size = 256 | tvERROR_NONE | Should be successful |
-| 05 | Compare the set and get values for each color | pData_R[i] = getData_R[i], pData_G[i] = getData_G[i], pData_B[i] = getData_B[i] | pData_R[i] = getData_R[i], pData_G[i] = getData_G[i], pData_B[i] = getData_B[i] | Should be successful |
-| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Gamma Table using SetGammaTable() with valid buffers | pData_R =  0 to 1023, pData_G = 0 to 1023, pData_B = 0 to 1023, size = 256 | tvERROR_NONE | Should be successful |
+| 03 | Get the Gamma Table using GetGammaTable() with valid buffers | getData_R = valid buffer, getData_G = valid buffer, getData_B = valid buffer, size = 256 | tvERROR_NONE | Should be successful |
+| 04 | Compare the set and get values for each color | pData_R[i] = getData_R[i], pData_G[i] = getData_G[i], pData_B[i] = getData_B[i] | pData_R[i] = getData_R[i], pData_G[i] = getData_G[i], pData_B[i] = getData_B[i] | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B[Create three arrays of unsigned short values]
+    A[TvInit] -->|Success| B{Iterate through <br> size value}
+    B --> C[SetGammaTable with valid <br> values of R,G,B]
     A -->|Failure| A1[Test case fail]
-    B -->|Success| C[SetGammaTable]
-    B -->|Failure| B1[Test case fail]
     C -->|Success| D[GetGammaTable]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E[Compare values]
-    D -->|Failure| D1[Test case fail]
-    E -->|Success| F[TvTerm]
-    E -->|Failure| E1[Test case fail]
+    D -->|Success, <br> get and set matches| B
+    B -->|End of loop| F[TvTerm]
     F -->|Success| G[Test case pass]
     F -->|Failure| F1[Test case fail]
 ```
@@ -1697,21 +1613,21 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV settings using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Get the default gamma table for standard color temperature using GetDefaultGammaTable() | colortemp = tvColorTemp_STANDARD, pData_R = valid array, pData_G = valid array, pData_B = valid array, size = 256 | tvERROR_NONE | Should be successful |
-| 03 | Check if the returned gamma values for red, green and blue are in the range 0 - 65535 | pData_R = valid array, pData_G = valid array, pData_B = valid array | None | Should be successful |
+| 02 | Get the default gamma table for standard color temperature using GetDefaultGammaTable() | colortemp = tvColorTemp_STANDARD to tvColorTemp_MAX-1, pData_R = valid array, pData_G = valid array, pData_B = valid array, size = 256 | tvERROR_NONE | Should be successful |
+| 03 | Check if the returned gamma values for red, green and blue are in the range 0 - 65535 | |  (pData_R, pData_G,pData_B) = 0 to 65535| Should be successful |
 | 04 | Terminate the TV settings using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit is called] -->|Return status is tvERROR_NONE| B[GetDefaultGammaTable is called with valid color temperature and arrays]
-A -->|Return status is not tvERROR_NONE| A1[Test case 37 fails]
-B -->|Return status is tvERROR_NONE| C[Check values in pData_R, pData_G, and pData_B arrays]
-B -->|Return status is not tvERROR_NONE| B1[Test case 37 fails]
-C -->|Values are within valid range| D[TvTerm is called]
-C -->|Values are not within valid range| C1[Test case 37 fails]
-D -->|Return status is tvERROR_NONE| E[Test case 37 passes]
-D -->|Return status is not tvERROR_NONE| D1[Test case 37 fails]
+A[TvInit is called] -->| tvERROR_NONE| Loop{Iterate through valid <br>color temperatures}
+Loop --> B[GetDefaultGammaTable]
+A -->|not tvERROR_NONE| A1[Test case fail]
+B -->|tvERROR_NONE| C[Check values in pData_R, <br> pData_G, and pData_B arrays]
+C -->|Values = 0 to 65535| Loop
+Loop -->|End of loop|D[TvTerm is called]
+D -->| tvERROR_NONE| E[Test case pass]
+D -->|not tvERROR_NONE| D1[Test case fail]
 ```
 
 
@@ -1739,27 +1655,22 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV settings using TvInit | None | tvERROR_NONE | Should be successful |
-| 02 | Set the Dv Tmax Value using SetDvTmaxValue | setValue = 5000 | tvERROR_NONE | Should be successful |
-| 03 | If SetDvTmaxValue fails, terminate the TV settings using TvTerm and return | None | None | Should be successful |
-| 04 | Get the Dv Tmax Value using GetDvTmaxValue | getValue = address of integer variable | tvERROR_NONE | Should be successful |
-| 05 | If GetDvTmaxValue fails, terminate the TV settings using TvTerm and return | None | None | Should be successful |
-| 06 | Assert that the set value and the retrieved value are equal | setValue = 5000, getValue = retrieved value | setValue should be equal to getValue | Should be successful |
-| 07 | Terminate the TV settings using TvTerm | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Dv Tmax Value using SetDvTmaxValue for 4 different values | setValue = random(0-10000) | tvERROR_NONE | Should be successful |
+| 03 | Get the Dv Tmax Value using GetDvTmaxValue | getValue = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Assert that the set value and the retrieved value are equal | | setValue = getValue | Should be successful |
+| 05 | Terminate the TV settings using TvTerm | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    Start(Start) --> Step1
-    Step1{Call TvInit API} -->|Success| Step2
-    Step1 -->|Failure| TestcaseFail1[Test case 38: Fail]
-    Step2{Call SetDvTmaxValue API with value in range 0 to 10000} -->|Success| Step3
-    Step2 -->|Failure| TestcaseFail2[Test case 38: Fail]
-    Step3{Call GetDvTmaxValue API} -->|Success| Step4
-    Step3 -->|Failure| TestcaseFail3[Test case 38: Fail]
-    Step4{Verify retrieved value matches set value} -->|Success| Step5
-    Step4 -->|Failure| TestcaseFail4[Test case 38: Fail]
-    Step5{Call TvTerm API} -->|Success| End(End)
-    Step5 -->|Failure| TestcaseFail5[Test case 38: Fail]
+    Step1[Call TvInit API] -->|Success| Loop{Iterate through <br> 4 valid values}
+    Loop --> Step2[Call SetDvTmaxValue API]
+    Step1 -->|Failure| Fail1[Test case Fail]
+    Step2 -->|Success| Step3[Call GetDvTmaxValue API]
+    Step3 -->|Success, <br> matches set value| Loop
+    Loop --> Step5[Call TvTerm API]
+    Step5 -->|Success| Step6[Testcase success]
+    Step5 -->|Failure| TestcaseFail5[Test case Fail]
 ```
 
 
@@ -1787,7 +1698,7 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Invoke GetSupportedComponentColor() with valid address | blComponentColor = valid address | tvERROR_NONE | Should be successful |
+| 02 | Invoke GetSupportedComponentColor() with valid address | blComponentColor = valid buffer | tvERROR_NONE | Should be successful |
 | 03 | Compare the returned value with the value in the platform-supported configurations file | blComponentColor, "SupportedComponentColor" | Equal values | Should be successful |
 | 04 | Loop through the indices of the returned value and check if the component color at each index is supported | blComponentColor = returned value | None | Should be successful |
 | 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
@@ -1795,15 +1706,10 @@ If user chose to run the test in interactive mode, then the test case has to be 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|tvERROR_NONE| B[Declare integer variable]
+    A[TvInit] -->|tvERROR_NONE|C[GetSupportedComponentColor]
     A -->|Failure| A1[Test case fail]
-    B --> C[GetSupportedComponentColor]
-    B -->|Failure| B1[Test case fail]
-    C -->|tvERROR_NONE| D[Compare with Sink-4K-TvSettings.yaml]
-    C -->|Failure| C1[Test case fail]
-    D --> E[Loop through indices]
-    D -->|Failure| D1[Test case fail]
-    E --> F[TvTerm]
+    C -->|tvERROR_NONE| D[Compare with profile <br> Loop through indices]
+    D --> F[TvTerm]
     F -->|tvERROR_NONE| G[Test case pass]
     F -->|Failure| F1[Test case fail]
 ```
@@ -1834,30 +1740,23 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
 | 02 | Set the CMS state to true using SetCMSState() | state = true | tvERROR_NONE | Should be successful |
-| 03 | For each color component, set a random saturation value between 0 and 100 using SetCurrentComponentSaturation() | color = color component, saturation = random value between 0 and 100 | tvERROR_NONE | Should be successful |
-| 04 | Get the current component saturation using GetCurrentComponentSaturation() | color = color component, saturation = pointer to saturation variable | tvERROR_NONE | Should be successful |
-| 05 | Assert that the set saturation value matches the retrieved saturation value | setSaturation = set value, saturation = retrieved value | setSaturation should be equal to saturation | Should be successful |
+| 03 | For each color component, set a random saturation value between 0 and 100 using SetCurrentComponentSaturation() | color =tvDataColor_NONE to tvDataColor_MAX, saturation = random(0-100) | tvERROR_NONE | Should be successful |
+| 04 | Get the current component saturation using GetCurrentComponentSaturation() | color = color component, saturation = valid buffer | tvERROR_NONE | Should be successful |
+| 05 | Assert that the set saturation value matches the retrieved saturation value | | setSaturation = saturation | Should be successful |
 | 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B[SetCMSState(true)]
-    B -->|Success| C[SetCurrentComponentSaturation(color, saturation)]
-    C -->|Success| D[GetCurrentComponentSaturation(color)]
-    D -->|Success, Saturation matches| E[SetCurrentComponentSaturation(next color, saturation)]
-    E -->|Success| F[GetCurrentComponentSaturation(next color)]
-    F -->|Success, Saturation matches| G[SetCurrentComponentSaturation(next color, saturation)]
-    G -->|Success| H[GetCurrentComponentSaturation(next color)]
-    H -->|Success, Saturation matches| I[TvTerm]
+    A[TvInit] -->|Success| B[SetCMSState with true]
+    B -->|Success| Loop{Iterate through <br> color component}
+    Loop --> C[SetCurrentComponentSaturation]
+    C -->|Success| D[GetCurrentComponentSaturation]
+    D -->|Success, <br> Saturation matches| Loop
+    Loop -->|End of loop|I[TvTerm]
+    I -->|Success| E[Test case success]
     A -->|Failure| J[Test case fail]
     B -->|Failure| K[Test case fail]
-    C -->|Failure| L[Test case fail]
-    D -->|Failure, Saturation doesn't match| M[Test case fail]
-    E -->|Failure| N[Test case fail]
-    F -->|Failure, Saturation doesn't match| O[Test case fail]
-    G -->|Failure| P[Test case fail]
-    H -->|Failure, Saturation doesn't match| Q[Test case fail]
     I -->|Failure| R[Test case fail]
 ```
 
@@ -1887,27 +1786,23 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
 | 02 | Set CMS state to true using SetCMSState() | state = true | tvERROR_NONE | Should be successful |
-| 03 | Loop through each color and hue value. Set the current component hue using SetCurrentComponentHue() | color = tvDataColor_RED to tvDataColor_MAX, hue = 0 to 100 | tvERROR_NONE | Should be successful |
-| 04 | Get the current component hue using GetCurrentComponentHue() | color = tvDataColor_RED to tvDataColor_MAX | tvERROR_NONE, hue value should match the set value | Should be successful |
+| 03 | Loop through each color and hue value. Set the current component hue using SetCurrentComponentHue() | color = tvDataColor_NONE to tvDataColor_MAX, hue = random(0-100) | tvERROR_NONE | Should be successful |
+| 04 | Get the current component hue using GetCurrentComponentHue() and verify | | tvERROR_NONE, hue = set value | Should be successful |
 | 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|Success| B[SetCMSState(true)]
-    B -->|Success| C[SetCurrentComponentHue(color, hue)]
-    B -->|Failure| Bf[Test case fail]
-    C -->|Success| D[Verify SetCurrentComponentHue returns tvERROR_NONE]
-    C -->|Failure| Cf[Test case fail]
-    D -->|Success| E[GetCurrentComponentHue(color)]
-    D -->|Failure| Df[Test case fail]
-    E -->|Success| F[Verify GetCurrentComponentHue returns tvERROR_NONE and hue matches]
-    E -->|Failure| Ef[Test case fail]
-    F -->|Success| G[Repeat for all colors]
-    F -->|Failure| Ff[Test case fail]
-    G --> H[TvTerm]
-    H -->|Success| I[Test case success]
-    H -->|Failure| Hf[Test case fail]
+    A[TvInit] -->|Success| B[SetCMSState with true]
+    B -->|Success| Loop{Iterate through <br> color component}
+    Loop --> C[SetCurrentComponentHue]
+    C -->|Success| D[GetCurrentComponentHue]
+    D -->|Success, <br> Hue matches| Loop
+    Loop -->|End of loop|I[TvTerm]
+    I -->|Success| E[Test case success]
+    A -->|Failure| J[Test case fail]
+    B -->|Failure| K[Test case fail]
+    I -->|Failure| R[Test case fail]
 ```
 
 
@@ -1937,28 +1832,23 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
 | 02 | Set CMS state to true using SetCMSState() | state = true | tvERROR_NONE | Should be successful |
-| 03 | Loop through each color component. Set the luma value for the current color component using SetCurrentComponentLuma() | color = color component, lumaSet = 15 | tvERROR_NONE | Should be successful |
-| 04 | Get the luma value for the current color component using GetCurrentComponentLuma() | color = color component | tvERROR_NONE, luma = lumaSet | Should be successful |
+| 03 | Loop through each color component. Set the luma value for the current color component using SetCurrentComponentLuma() | color = tvDataColor_NONE to tvDataColor_MAX, lumaSet = random(0-30) | tvERROR_NONE | Should be successful |
+| 04 | Get the luma value for the current color component using GetCurrentComponentLuma() | | tvERROR_NONE, luma = lumaSet | Should be successful |
 | 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-A[TvInit()] -->|Success| B[SetCMSState(true)]
-A -->|Failure| A1[Test case fail]
-B -->|Success| C[For each color in tvDataComponentColor_t]
-B -->|Failure| B1[Test case fail]
-C --> D[SetCurrentComponentLuma(color, luma)]
-D -->|Success| E[Verify return value is tvERROR_NONE]
-D -->|Failure| D1[Test case fail]
-E --> F[GetCurrentComponentLuma(color)]
-F -->|Success| G[Verify return value is tvERROR_NONE]
-F -->|Failure| F1[Test case fail]
-G --> H[Verify luma value matches set value]
-H --> C
-C --> I[TvTerm()]
-I -->|Success| J[Test case pass]
-I -->|Failure| I1[Test case fail]
+    A[TvInit] -->|Success| B[SetCMSState with true]
+    B -->|Success| Loop{Iterate through <br> color component}
+    Loop --> C[SetCurrentComponentLuma]
+    C -->|Success| D[GetCurrentComponentLuma]
+    D -->|Success, <br> luma matches| Loop
+    Loop -->|End of loop|I[TvTerm]
+    I -->|Success| E[Test case success]
+    A -->|Failure| J[Test case fail]
+    B -->|Failure| K[Test case fail]
+    I -->|Failure| R[Test case fail]
 ```
 
 
@@ -1987,27 +1877,26 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
 | 02 | Set the CMS state to true using SetCMSState() | enableCMSState = true | tvERROR_NONE | Should be successful |
-| 03 | Get the CMS state using GetCMSState() | enableCMSState = address of enableCMSState variable | tvERROR_NONE, enableCMSState = true | Should be successful |
+| 03 | Get the CMS state using GetCMSState() and verify| enableCMSState = valid buffer | tvERROR_NONE, enableCMSState = true | Should be successful |
 | 04 | Set the CMS state to false using SetCMSState() | enableCMSState = false | tvERROR_NONE | Should be successful |
-| 05 | Get the CMS state using GetCMSState() | enableCMSState = address of enableCMSState variable | tvERROR_NONE, enableCMSState = false | Should be successful |
+| 05 | Get the CMS state using GetCMSState() and verify| enableCMSState = valid buffer  | tvERROR_NONE, enableCMSState = false | Should be successful |
 | 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    Start(Start) --> Step1
-    Step1{Call TvInit API} -->|tvERROR_NONE| Step2
-    Step1 -->|Failure| TestcaseFail1[Test case 43 fail]
-    Step2{Call SetCMSState API with true} -->|tvERROR_NONE| Step3
-    Step2 -->|Failure| TestcaseFail2[Test case 43 fail]
-    Step3{Call GetCMSState API, check true} -->|Success| Step4
-    Step3 -->|Failure| TestcaseFail3[Test case 43 fail]
-    Step4{Call SetCMSState API with false} -->|tvERROR_NONE| Step5
-    Step4 -->|Failure| TestcaseFail4[Test case 43 fail]
-    Step5{Call GetCMSState API, check false} -->|Success| Step6
-    Step5 -->|Failure| TestcaseFail5[Test case 43 fail]
-    Step6{Call TvTerm API} -->|tvERROR_NONE| End(End)
-    Step6 -->|Failure| TestcaseFail6[Test case 43 fail]
+    Step1[Call TvInit API] -->|tvERROR_NONE| Step2
+    Step1 -->|Failure| TestcaseFail1[Test case fail]
+    Step2[Call SetCMSState API with true] -->|tvERROR_NONE| Step3
+    Step2 -->|Failure| TestcaseFail2[Test case fail]
+    Step3[Call GetCMSState API, check true] -->|Success, true| Step4
+    Step3 -->|Failure| TestcaseFail3[Test case fail]
+    Step4[Call SetCMSState API with false] -->|tvERROR_NONE| Step5
+    Step4 -->|Failure| TestcaseFail4[Test case fail]
+    Step5[Call GetCMSState API, check false]-->|Success, false| Step6
+    Step5 -->|Failure| TestcaseFail5[Test case fail]
+    Step6[Call TvTerm API] -->|tvERROR_NONE| Step7[Test case success]
+    Step6 -->|Failure| TestcaseFail6[Test case fail]
 ```
 
 
@@ -2042,22 +1931,15 @@ If user chose to run the test in interactive mode, then the test case has to be 
 
 ```mermaid
 graph TB
-    A[TvInit()] -->|Success| B{Loop through video sources, formats, PQ modes}
+    A[TvInit] -->|Success| B{Loop through <br> video sources, formats, <br>PQ modes}
     A -->|Failure| A1[Test case fail]
-    B -->|Success| C[SaveBrightness(), SaveContrast(), SaveSaturation(), SaveHue()]
-    B -->|Failure| B1[Test case fail]
-    C -->|Success| D[SetCurrentComponentSaturation()]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E[SaveDvTmaxValue()]
-    D -->|Failure| D1[Test case fail]
-    E -->|Success| F[SaveLowLatencyState()]
-    E -->|Failure| E1[Test case fail]
-    F -->|Success| G{Loop through video sources, formats, PQ modes}
-    F -->|Failure| F1[Test case fail]
-    G -->|Success| H[GetPQParams()]
-    G -->|Failure| G1[Test case fail]
-    H -->|Success| I[TvTerm()]
-    H -->|Failure| H1[Test case fail]
+    B -->|Success| C[SaveBrightness, SaveContrast,<br> SaveSaturation, SaveHue]
+    C -->|Success| D[SetCurrentComponentSaturation,<br> SaveDvTmaxValue <br> SaveLowLatencyState]
+    D -->|Success| G{Loop through video sources,<br> formats, PQ modes}
+    G -->|Success| H[GetPQParams]
+    H -->|Success| G
+    G -->|ENd of loop|B
+    B -->|ENd of loop| I[TvTerm]
     I -->|Success| J[Test case success]
     I -->|Failure| I1[Test case fail]
 ```
@@ -2087,48 +1969,29 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Loop through each color temperature in tvColorTemp_t and retrieve the target x and y coordinates for the panel gamma using GetTVGammaTarget() | colorTemp = tvColorTemp_STANDARD, tvColorTemp_WARM, tvColorTemp_COLD, tvColorTemp_USER, tvColorTemp_BOOST_STANDARD, tvColorTemp_BOOST_WARM, tvColorTemp_BOOST_COLD, tvColorTemp_BOOST_USER, tvColorTemp_SUPERCOLD, tvColorTemp_BOOST_SUPERCOLD | x and y coordinates should be within the range of 0 to 1.0 | Should be successful |
+| 02 | Loop through each color temperature in tvColorTemp_t and retrieve the target x and y coordinates for the panel gamma using GetTVGammaTarget() | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX  | x and y = 0 to 1.0 | Should be successful |
 | 03 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    Start(Start) --> TvInit
-    TvInit{Call TvInit API} -->|Return status is tvERROR_NONE| GetTVGammaTarget1
-    TvInit -->|Return status is not tvERROR_NONE| TestcaseFail1[Test case fail]
-    GetTVGammaTarget1{Call GetTVGammaTarget API with tvColorTemp_STANDARD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget2
-    GetTVGammaTarget1 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail2[Test case fail]
-    GetTVGammaTarget2{Call GetTVGammaTarget API with tvColorTemp_WARM} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget3
-    GetTVGammaTarget2 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail3[Test case fail]
-    GetTVGammaTarget3{Call GetTVGammaTarget API with tvColorTemp_COLD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget4
-    GetTVGammaTarget3 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail4[Test case fail]
-    GetTVGammaTarget4{Call GetTVGammaTarget API with tvColorTemp_USER} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget5
-    GetTVGammaTarget4 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail5[Test case fail]
-    GetTVGammaTarget5{Call GetTVGammaTarget API with tvColorTemp_BOOST_STANDARD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget6
-    GetTVGammaTarget5 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail6[Test case fail]
-    GetTVGammaTarget6{Call GetTVGammaTarget API with tvColorTemp_BOOST_WARM} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget7
-    GetTVGammaTarget6 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail7[Test case fail]
-    GetTVGammaTarget7{Call GetTVGammaTarget API with tvColorTemp_BOOST_COLD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget8
-    GetTVGammaTarget7 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail8[Test case fail]
-    GetTVGammaTarget8{Call GetTVGammaTarget API with tvColorTemp_BOOST_USER} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget9
-    GetTVGammaTarget8 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail9[Test case fail]
-    GetTVGammaTarget9{Call GetTVGammaTarget API with tvColorTemp_SUPERCOLD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget10
-    GetTVGammaTarget9 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail10[Test case fail]
-    GetTVGammaTarget10{Call GetTVGammaTarget API with tvColorTemp_BOOST_SUPERCOLD} -->|x and y coordinates are within 0 to 1.0| TvTerm
-    GetTVGammaTarget10 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail11[Test case fail]
-    TvTerm{Call TvTerm API} -->|Return status is tvERROR_NONE| End(End)
-    TvTerm -->|Return status is not tvERROR_NONE| TestcaseFail12[Test case fail]
+    TvInit[Call TvInit API] -->|tvERROR_NONE| Loop{Iterate through <br> color temperature}
+    Loop --> GetTVGammaTarget1
+    TvInit -->|not tvERROR_NONE| TestcaseFail1[Test case fail]
+    GetTVGammaTarget1[Call GetTVGammaTarget] -->|x and y coordinates<br> within 0 to 1.0| Loop
+    Loop -->|End of loop| TvTerm
+    TvTerm[Call TvTerm API] -->|tvERROR_NONE| Success[Test case success]
+    TvTerm -->|not tvERROR_NONE| TestcaseFail12[Test case fail]
 ```
-
 
 ### Test 46
 
 |Title|Details|
 |--|--|
-|Function Name|`test_l2_tvSettings_SetAndGetRGBPattern`|
-|Description|Set and Gets the RGB Pattern within the range ( 0 - 255 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Function Name|`test_l2_tvSettings_GetMaxGainValue`|
+|Description|Gets the max gamma/WB gain value for the platform and check it is in the range. The valid range can be from 2^10 till (2^31)-1.|
 |Test Group|Module : 02|
-|Test Case ID|46|
+|Test Case ID|046|
 |Priority|High|
 
 **Pre-Conditions :**
@@ -2144,29 +2007,20 @@ If user chose to run the test in interactive mode, then the test case has to be 
 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
-| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set the RGB pattern using SetRGBPattern() | r_set = 100, g_set = 150, b_set = 200 | tvERROR_NONE | Should be successful |
-| 03 | Get the RGB pattern using GetRGBPattern() | r_get, g_get, b_get | tvERROR_NONE | Should be successful |
-| 04 | Check if the retrieved RGB values match the set values | r_get, g_get, b_get | r_set, g_set, b_set | Should be successful |
-| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
-
+| 01 | Invoke TvInit() to initialize the TV settings | No input data | tvERROR_NONE | Should be successful |
+| 02 | Invoke GetMaxGainValue() to get the maximum gain value | No input data | Gain value = (1024 to 2147483647)| Should be successful |
+| 03 | Invoke TvTerm() to terminate the TV settings | No input data | tvERROR_NONE | Should be successful |
 
 ```mermaid
 graph TB
-    A[TvInit()] -->|Success| B[SetRGBPattern()]
-    A -->|Failure| A1[Test case fail]
-    B -->|Success| C[Verify SetRGBPattern() returns tvERROR_NONE]
-    B -->|Failure| B1[Test case fail]
-    C -->|Success| D[GetRGBPattern()]
-    C -->|Failure| C1[Test case fail]
-    D -->|Success| E[Verify GetRGBPattern() returns tvERROR_NONE]
-    D -->|Failure| D1[Test case fail]
-    E -->|Success| F[Check RGB values match]
-    E -->|Failure| E1[Test case fail]
-    F -->|Success| G[TvTerm()]
-    F -->|Failure| F1[Test case fail]
-    G -->|Success| H[Test case pass]
-    G -->|Failure| G1[Test case fail]
+A[Call TvInit API] -->|Success| B[Call GetMaxGainValue API]
+A -->|Failure| A1[Test case fail]
+B -->|Success| C[Check returned gain value <br> within 1024 to 2147483647 ]
+B -->|Failure| B1[Test case fail]
+C -->|Success| D[Call TvTerm API]
+C -->|Failure| C1[Test case fail]
+D -->|Success| E[Test case success]
+D -->|Failure| D1[Test case fail]
 ```
 
 
@@ -2174,8 +2028,8 @@ graph TB
 
 |Title|Details|
 |--|--|
-|Function Name|`test_l2_tvSettings_SetAndGetGrayPattern`|
-|Description|Set and Gets the Gray Pattern within the range ( 0 - 255 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Function Name|`test_l2_tvSettings_SetAndGetRGBPattern`|
+|Description|Set and Gets the RGB Pattern within the range ( 0 - 255 ). The retrieved value should match the set value. Get values are retrieved from the database.|
 |Test Group|Module : 02|
 |Test Case ID|47|
 |Priority|High|
@@ -2194,24 +2048,22 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Set the Gamma Pattern Mode to true using SetGammaPatternMode() | Mode = true | tvERROR_NONE | Should be successful |
-| 03 | Set the Gray Pattern using SetGrayPattern() | YUVValue = 100 | tvERROR_NONE | Should be successful |
-| 04 | Get the Gray Pattern using GetGrayPattern() | get_YUVValue = valid buffer | tvERROR_NONE, YUVValue = 100 | Should be successful |
-| 05 | If the status is not tvERROR_NONE or the set and get YUVValues do not match, terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the RGB pattern using SetRGBPattern() for 4 valid values | (r_set, g_set, b_set) = (0 to 255)| tvERROR_NONE | Should be successful |
+| 03 | Get the RGB pattern using GetRGBPattern() | r_get, g_get, b_get | tvERROR_NONE | Should be successful |
+| 04 | Check if the retrieved RGB values match the set values | r_set = r_get, g_set = g_get, b_set = b_get | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit] -->|tvERROR_NONE| B[SetGammaPatternMode]
+    A[TvInit] -->|Success| Loop{Iterate through <br> 4 valid values}
+    Loop --> B[SetRGBPattern]
     A -->|Failure| A1[Test case fail]
-    B -->|tvERROR_NONE| C[SetGrayPattern]
-    B -->|Failure| B1[Test case fail]
-    C -->|tvERROR_NONE| D[GetGrayPattern]
-    C -->|Failure| C1[Test case fail]
-    D -->|tvERROR_NONE, YUVValue matches| E[TvTerm]
-    D -->|Failure| D1[Test case fail]
-    E -->|tvERROR_NONE| F[Test case success]
-    E -->|Failure| E1[Test case fail]
+    B -->|tvERROR_NONE| D[GetRGBPattern]
+    D -->|tvERROR_NONE,<br> get and set matches|Loop
+    Loop -->|End of loop|G[TvTerm]
+    G -->|Success| H[Test case pass]
+    G -->|Failure| G1[Test case fail]
 ```
 
 
@@ -2219,8 +2071,8 @@ graph TB
 
 |Title|Details|
 |--|--|
-|Function Name|`test_l2_tvSettings_RetrieveOpenCircuitStatus`|
-|Description|Verifies the functionality of retrieving the current open circuit status of the backlight hardware. It ensures that the returned status indicates whether any `LED` fault is detected.|
+|Function Name|`test_l2_tvSettings_SetAndGetGrayPattern`|
+|Description|Set and Gets the Gray Pattern within the range ( 0 - 255 ). The retrieved value should match the set value. Get values are retrieved from the database.|
 |Test Group|Module : 02|
 |Test Case ID|48|
 |Priority|High|
@@ -2239,23 +2091,24 @@ If user chose to run the test in interactive mode, then the test case has to be 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
-| 02 | Retrieve the open circuit status using GetOpenCircuitStatus() | status = valid pointer | tvERROR_NONE | Should be successful |
-| 03 | Check if the status indicates an LED fault | status >= 1 | LED fault detected | Should be successful |
-| 04 | Check if the status indicates no LED fault | status = 0 | No LED fault detected | Should be successful |
-| 05 | Check if the status value is invalid | status < 0 | Invalid status value | Should fail |
-| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Gamma Pattern Mode to true using SetGammaPatternMode() | Mode = true | tvERROR_NONE | Should be successful |
+| 03 | Set the Gray Pattern using SetGrayPattern()  for 4 valid values| YUVValue = random(0-255)| tvERROR_NONE | Should be successful |
+| 04 | Get the Gray Pattern using GetGrayPattern() | get_YUVValue = valid buffer | tvERROR_NONE, get_YUVValue = YUVValue | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit()] -->|tvERROR_NONE| B[GetOpenCircuitStatus()]
-    A -->|!=tvERROR_NONE| A1[Test case fail]
-    B -->|tvERROR_NONE| C[Check returned status]
-    B -->|!=tvERROR_NONE| B1[Test case fail]
-    C -->|Status >= 1 or Status == 0| D[TvTerm()]
-    C -->|Status < 0 or Status > 1| C1[Test case fail]
-    D -->|tvERROR_NONE| E[Test case pass]
-    D -->|!=tvERROR_NONE| D1[Test case fail]
+    A[TvInit] -->|tvERROR_NONE| B[SetGammaPatternMode true]
+    A -->|Failure| A1[Test case fail]
+    B -->|tvERROR_NONE| Loop{Iterate through <br> 4 valid values}
+    Loop --> C[SetGrayPattern]
+    B -->|Failure| B1[Test case fail]
+    C -->|tvERROR_NONE| D[GetGrayPattern]
+    D -->|tvERROR_NONE, <br>YUVValue matches| Loop
+    Loop -->|End of loop| E[TvTerm]
+    E -->|tvERROR_NONE| F[Test case success]
+    E -->|Failure| E1[Test case fail]
 ```
 
 
@@ -2263,8 +2116,8 @@ graph TB
 
 |Title|Details|
 |--|--|
-|Function Name|`test_l2_tvSettings_EnableAndGetDynamicContrast`|
-|Description|Enable Dynamic Contrast - Verifies the functionality of enabling or disabling the dynamic contrast module. Check the status by get dynamic contrast.|
+|Function Name|`test_l2_tvSettings_RetrieveOpenCircuitStatus`|
+|Description|Verifies the functionality of retrieving the current open circuit status of the backlight hardware. It ensures that the returned status indicates whether any `LED` fault is detected.|
 |Test Group|Module : 02|
 |Test Case ID|49|
 |Priority|High|
@@ -2282,26 +2135,74 @@ If user chose to run the test in interactive mode, then the test case has to be 
 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Retrieve the open circuit status using GetOpenCircuitStatus() | status = valid buffer | tvERROR_NONE | Should be successful |
+| 03 | Check if the status indicates an LED fault | status >= 1 | LED fault detected | Should be successful |
+| 04 | Check if the status indicates no LED fault | status = 0 | No LED fault detected | Should be successful |
+| 05 | Check if the status value is invalid | status < 0 | Invalid status value | Should fail |
+| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|tvERROR_NONE| B[GetOpenCircuitStatus]
+    A -->|!=tvERROR_NONE| A1[Test case fail]
+    B -->|tvERROR_NONE| C[Check returned <br> status]
+    B -->|!=tvERROR_NONE| B1[Test case fail]
+    C -->|Status >= 1| F[LED fault detected]
+    C -->|Status == 0| G[LED fault not <br> detected]
+    C -->|Status < 0 <br> or Status > 1| H[Invalid status]
+    F -->D[TvTerm]
+    G -->D
+    H --> D
+    D -->|tvERROR_NONE| E[Test case pass]
+    D -->|!=tvERROR_NONE| D1[Test case fail]
+```
+
+
+### Test 50
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_EnableAndGetDynamicContrast`|
+|Description|Enable Dynamic Contrast - Verifies the functionality of enabling or disabling the dynamic contrast module. Check the status by get dynamic contrast.|
+|Test Group|Module : 02|
+|Test Case ID|50|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
 | 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
 | 02 | Enable Dynamic Contrast using EnableDynamicContrast() | Enable = true | tvERROR_NONE | Should be successful |
-| 03 | Get Dynamic Contrast status using GetDynamicContrast() | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, "enabled" | Should be successful |
+| 03 | Get Dynamic Contrast status using GetDynamicContrast() and verify | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, "enabled" | Should be successful |
 | 04 | Disable Dynamic Contrast using EnableDynamicContrast() | Enable = false | tvERROR_NONE | Should be successful |
-| 05 | Get Dynamic Contrast status using GetDynamicContrast() | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, "disabled" | Should be successful |
+| 05 | Get Dynamic Contrast status using GetDynamicContrast() and verify | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, "disabled" | Should be successful |
 | 06 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
 
 
 ```mermaid
 graph TB
-    A[TvInit()] -->|tvERROR_NONE| B[EnableDynamicContrast(true)]
+    A[TvInit] -->|tvERROR_NONE| B[EnableDynamicContrast with true]
     A -->|!=tvERROR_NONE| A1[Test case fail]
-    B -->|tvERROR_NONE| C[GetDynamicContrast()]
+    B -->|tvERROR_NONE| C[GetDynamicContrast]
     B -->|!=tvERROR_NONE| B1[Test case fail]
-    C -->|tvERROR_NONE and output=="enabled"| D[EnableDynamicContrast(false)]
-    C -->|!=tvERROR_NONE or output!="enabled"| C1[Test case fail]
-    D -->|tvERROR_NONE| E[GetDynamicContrast()]
+    C -->|tvERROR_NONE<br> output='enabled'| D[EnableDynamicContrast with false]
+    C -->|!=tvERROR_NONE| C1[Test case fail]
+    D -->|tvERROR_NONE| E[GetDynamicContrast]
     D -->|!=tvERROR_NONE| D1[Test case fail]
-    E -->|tvERROR_NONE and output=="disabled"| F[TvTerm()]
-    E -->|!=tvERROR_NONE or output!="disabled"| E1[Test case fail]
+    E -->|tvERROR_NONE or <br> output=='disabled'| F[TvTerm]
+    E -->|!=tvERROR_NONE| E1[Test case fail]
     F -->|tvERROR_NONE| G[Test case success]
     F -->|!=tvERROR_NONE| F1[Test case fail]
 ```

--- a/docs/pages/tvSettings_L2_Low-Level_TestSpecification.md
+++ b/docs/pages/tvSettings_L2_Low-Level_TestSpecification.md
@@ -1,0 +1,2309 @@
+# TVSETTINGS L2 Low Level Test Specification and Procedure Documentation
+
+## Table of Contents
+
+- [TVSETTINGS L2 Low Level Test Specification and Procedure Documentation](#tvsettings-l2-low-level-test-specification-and-procedure-documentation)
+
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+    - [Acronyms, Terms and Abbreviations](#acronyms-terms-and-abbreviations)
+    - [Definitions](#definitions)
+    - [References](#references)
+  - [Level 2 Test Procedure](#level-2-test-procedure)
+
+## Overview
+
+This document describes the level 2 testing suite for the TVSETTINGS module.
+
+### Acronyms, Terms and Abbreviations
+
+- `HAL` \- Hardware Abstraction Layer, may include some common components
+- `UT`  \- Unit Test(s)
+- `OEM`  \- Original Equipment Manufacture
+- `SoC`  \- System on a Chip
+
+### Definitions
+
+  - `ut-core` \- Common Testing Framework <https://github.com/rdkcentral/ut-core>, which wraps a open-source framework that can be expanded to the requirements for future framework.
+
+### References
+- `High Level Test Specification` - [tvSettings_Test_Spec.md](tvSettings_Test_Spec.md)
+
+## Level 2 Test Procedure
+
+The following functions are expecting to test the module operates correctly.
+
+### Test 1
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetSupportedVideoFormats`|
+|Description|Get TV supported video formats and verify that the test provides all supported video formats and their count (minimum is 1 and maximum is VIDEO_FORMAT_MAX). Compare the test results with the platform-supported configurations file 'Sink-4K-TvSettings.yaml' using the path 'VideoFormat/index' and loop through the indices. Using the path 'VideoFormat/numberOfFormats' compare the count.|
+|Test Group|Module : 02|
+|Test Case ID|001|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Get supported video formats using GetTVSupportedVideoFormats | videoFormats = valid buffer, numberOfFormats = valid buffer | tvERROR_NONE | Should be successful |
+| 03 | Verify the number of formats | numberOfFormats = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Loop through the indices and verify each video format | videoFormats[i] = valid buffer | tvERROR_NONE | Should be successful |
+| 05 | Terminate TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|tvERROR_NONE| B[GetTVSupportedVideoFormats]
+    A -->|Failure| A1[Test case fail]
+    B -->|tvERROR_NONE| C[Compare video formats and count]
+    B -->|Failure| B1[Test case fail]
+    C -->|Match| D[TvTerm]
+    D -->|tvERROR_NONE| E[Test case success]
+    D -->|Failure| D1[Test case fail]
+```
+
+
+### Test 2
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetCurrentVideoFormat_NoVideoPlayback`|
+|Description|Verify getting the current video format when there is no video playback. Default is VIDEO_FORMAT_SDR|
+|Test Group|Module : 02|
+|Test Case ID|002|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Invoke TvInit with no input parameters | None | tvERROR_NONE | Should be successful |
+| 02 | Invoke GetCurrentVideoFormat with valid pointer to tvVideoFormatType_t variable and verify value | videoFormat = valid pointer | tvERROR_NONE, VIDEO_FORMAT_SDR | Should be successful |
+| 03 | Invoke TvTerm with no input parameters | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit] -->|tvERROR_NONE| B[GetCurrentVideoFormat]
+A -->|!= tvERROR_NONE| A1[Test case fail]
+B -->|tvERROR_NONE| C[Verify tvVideoFormatType_t <br> == VIDEO_FORMAT_SDR]
+B -->|!= tvERROR_NONE| B1[Test case fail]
+C -->|True| D[TvTerm]
+D -->|tvERROR_NONE| E[Test case success]
+D -->|!= tvERROR_NONE| D1[Test case fail]
+```
+
+
+### Test 3
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_VerifyCurrentVideoResolution`|
+|Description|Verify that the current video resolution of the primary video is 'tvVideoResolution_NONE' when playback has not started or has been stopped.|
+|Test Group|Module : 02|
+|Test Case ID|003|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Get the current video resolution using GetCurrentVideoResolution | res = valid buffer | tvERROR_NONE | Should be successful |
+| 03 | Check if the resolution value is 'tvVideoResolution_NONE' | resolutionValue = tvVideoResolution_NONE | tvVideoResolution_NONE | Should be successful |
+| 04 | Check if the frame height is 0 | frameHeight = 0 | 0 | Should be successful |
+| 05 | Check if the frame width is 0 | frameWidth = 0 | 0 | Should be successful |
+| 06 | Check if the video is not interlaced | isInterlaced = 0 | 0 | Should be successful |
+| 07 | If the status is not 'tvERROR_NONE', terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+| 08 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    TvInit[Call TvInit API] -->|tvERROR_NONE| GetCurrentVideoResolution
+    TvInit -->|!= tvERROR_NONE| TestcaseFail1[Test case fail]
+    GetCurrentVideoResolution[Call GetCurrentVideoResolution API] -->|Success| CheckResolutionValue
+    GetCurrentVideoResolution -->|Failure| TestcaseFail2[Test case fail]
+    CheckResolutionValue[Check resolutionValue field] -->|tvVideoResolution_NONE| CheckFrameHeight
+    CheckResolutionValue -->|!= tvVideoResolution_NONE| TestcaseFail3[Test case fail]
+    CheckFrameHeight[Check frameHeight field] -->|0| CheckFrameWidth
+    CheckFrameWidth[Check frameWidth field] -->|0| CheckIsInterlaced
+    CheckIsInterlaced[Check isInterlaced field] -->|0| TvTerm
+    TvTerm[Call TvTerm API] -->|tvERROR_NONE| TestcaseSuccess[Test case success]
+    TvTerm -->|!= tvERROR_NONE| TestcaseFail7[Test case fail]
+```
+
+
+### Test 4
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_VerifyFrameRateWhenStopped`|
+|Description|Verify that the current video frame rate of the primary video is 'tvVideoFrameRate_NONE' when playback has not started or has been stopped.|
+|Test Group|Module : 02|
+|Test Case ID|004|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Get the current video frame rate using GetCurrentVideoFrameRate  and verify the value| frameRate = valid buffer | tvERROR_NONE, frameRate = tvVideoFrameRate_NONE | Should be successful |
+| 03 | If the previous step was successful, terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+```mermaid
+graph TB
+A[TvInit API Call] -->|Success: tvERROR_NONE| B[GetCurrentVideoFrameRate API Call]
+A -->|Failure: Not tvERROR_NONE| A1[Test Case Fail]
+B -->|Success: tvVideoFrameRate_NONE| C[Verify Frame Rate is tvVideoFrameRate_NONE]
+B -->|Failure: Not tvVideoFrameRate_NONE| B1[Test Case Fail]
+C -->|Success| D[TvTerm API Call]
+D -->|Success: tvERROR_NONE| E[Test Case Success]
+D -->|Failure: Not tvERROR_NONE| D1[Test Case Fail]
+```
+
+
+### Test 5
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetTVSupportedVideoSources`|
+|Description|Get TV Supported Video Sources - Verify the test provides all supported video sources and their count( Min is 1 and Max is VIDEO_SOURCE_MAX). Compare the test results with the platform-supported configurations file 'Sink-4K-TvSettings.yaml' using the path 'VideoSource/index' and loop through the indices, using the path 'VideoSource/numberOfFormats' compare the count.|
+|Test Group|Module : 02|
+|Test Case ID|005|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Get supported video sources and their count using GetTVSupportedVideoSources() | videoSources = valid buffer, numberOfSources = valid buffer | tvERROR_NONE | Should be successful |
+| 03 | Verify the number of sources is between 1 and VIDEO_SOURCE_MAX | numberOfSources = returned value | True | Should be successful |
+| 04 | Loop through the indices and compare the test results with the platform-supported configurations file using the path 'VideoSource/index' | videoSources[i] = returned value, key = "VideoSource/index/i" | True | Should be successful |
+| 05 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|tvERROR_NONE| B[GetTVSupportedVideoSources]
+    A -->|!= tvERROR_NONE| A1[Test case fail]
+    B -->|tvERROR_NONE| C[Verify count of video sources]
+    B -->|!= tvERROR_NONE| B1[Test case fail]
+    C -->|1 <= count <= VIDEO_SOURCE_MAX| D[Compare video sources with Sink-4K-TvSettings.yaml]
+    D --> E[Compare count of video sources with configuration file]
+    E --> F[TvTerm]
+    F -->|tvERROR_NONE| G[Test case pass]
+    F -->|!= tvERROR_NONE| F1[Test case fail]
+```
+
+
+### Test 6
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_VerifyNoVideoSource`|
+|Description|Verify when there is no video source device is connected. Default is VIDEO_SOURCE_IP|
+|Test Group|Module : 02|
+|Test Case ID|006|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Invoke TvInit() to initialize the TV | None | tvERROR_NONE | Should be successful |
+| 02 | Invoke GetCurrentVideoSource() with valid pointer to get the current video source | currentSource = valid pointer | tvERROR_NONE, VIDEO_SOURCE_IP | Should be successful |
+| 03 | Invoke TvTerm() to terminate the TV | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|tvERROR_NONE| B[GetCurrentVideoSource]
+    A -->|!=tvERROR_NONE| A1[Test case fail]
+    B -->|VIDEO_SOURCE_IP| C[TvTerm]
+    B -->|!=VIDEO_SOURCE_IP| B1[Test case fail]
+    C -->|tvERROR_NONE| D[Test case success]
+    C -->|!=tvERROR_NONE| C1[Test case fail]
+```
+
+
+### Test 7
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetBacklight`|
+|Description|Sets and Gets the backlight within the valid range (0 - 100). The retrieved value should match the set value. Get values are retrieved from the `PQ` database.|
+|Test Group|Module : 02|
+|Test Case ID|007|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the backlight value using SetBacklight() | backlight = 50 | tvERROR_NONE | Should be successful |
+| 03 | Get the backlight value using GetBacklight() and verify with set value | getBacklight = valid buffer | tvERROR_NONE, backlight = 50 | Should be successful |
+| 04 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit] -->|Success| B[SetBacklight]
+A -->|Failure| A1[Test case fail]
+B -->|Success| D[GetBacklight]
+B -->|Failure| B1[Test case fail]
+D -->|Success| F[Verify get and set backlight value]
+D -->|Failure| D1[Test case fail]
+F -->|Success| G[TvTerm]
+G -->|Success| H[Test case success]
+G -->|Failure| G1[Test case fail]
+```
+
+
+### Test 8
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetBacklightFade`|
+|Description|Set and Gets the Back light fade within the valid ranges of from ( 0  - 100 ), to ( 0 - 100 ), current( 0 - 100) and duration (0 - 10000 ms). The retrieved value should match the set value. Get values are retrieved from the `PQ` database.|
+|Test Group|Module : 02|
+|Test Case ID|008|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Backlight Fade using SetBacklightFade() | from = 50, to = 100, duration = 5000 | tvERROR_NONE | Should be successful |
+| 03 | Get the current Backlight Fade using GetCurrentBacklightFade() | get_from, get_to, get_current | tvERROR_NONE | Should be successful |
+| 04 | Validate the set and get values of from and to | from = 50, to = 100 | from = get_from, to = get_to | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit] -->|Success| B[SetBacklightFade]
+A -->|Failure| A1[Test case fail]
+B -->|Success| D[GetCurrentBacklightFade]
+B -->|Failure| B1[Test case fail]
+D -->|Success| F[Check get and set to, from , current values match]
+D -->|Failure| D1[Test case fail]
+F -->|Success| G[TvTerm]
+G -->|Success| H[Test case success]
+G -->|Failure| G1[Test case fail]
+```
+
+
+### Test 9
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetSupportedBacklightModes`|
+|Description|Get Supported Back light Modes - verifies to get all the supported backlight modes. Compare the test results with the platform-supported configurations file 'Sink-4K-TvSettings.yaml' using the path 'BacklightControl/index' and loop through the indices.|
+|Test Group|Module : 02|
+|Test Case ID|009|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Get the supported backlight modes using GetSupportedBacklightModes | blModes = valid pointer | tvERROR_NONE | Should be successful |
+| 03 | Compare the obtained backlight modes with the platform-supported configurations file | blModes, "BacklightControl/index" | None | Should be successful |
+| 04 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit API Call] -->|tvERROR_NONE| B[GetSupportedBacklightModes API Call]
+    A -->|Not tvERROR_NONE| A1[Test Case Fail]
+    B -->|tvERROR_NONE| C[Compare supported mode with Sink-4K-TvSettings.yaml]
+    B -->|Not tvERROR_NONE| B1[Test Case Fail]
+    C -->|match| D[TvTerm API Call]
+    D -->|tvERROR_NONE| E[Test Case Success]
+    D -->|Not tvERROR_NONE| D1[Test Case Fail]
+
+
+### Test 10
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetBacklightMode`|
+|Description|Set and Gets the current Back light modes. The retrieved value should match the set value. Get values are retrieved from the `PQ` database.|
+|Test Group|Module : 02|
+|Test Case ID|10|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set current backlight mode using SetCurrentBacklightMode() | setMode = tvBacklightMode_MANUAL | tvERROR_NONE | Should be successful |
+| 03 | Get current backlight mode using GetCurrentBacklightMode() | getMode = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Validate the set and get backlight modes are same | setMode, getMode | setMode should be equal to getMode | Should be successful |
+| 05 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit] -->|tvERROR_NONE| B[SetCurrentBacklightMode]
+A -->|!=tvERROR_NONE| A1[Test case fail]
+B -->|tvERROR_NONE| C[GetCurrentBacklightMode]
+B -->|!=tvERROR_NONE| B1[Test case fail]
+C -->|tvERROR_NONE| D[Verify get and set Backlight Mode]
+C -->|!=tvERROR_NONE| C1[Test case fail]
+D -->|Match| E[TvTerm]
+E -->|tvERROR_NONE| F[Test case success]
+E -->|!=tvERROR_NONE| E1[Test case fail]
+```
+
+
+### Test 11
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetSupportedDimmingModes`|
+|Description|Gets TV Supported Dimming Modes - Verify the test provides all supported backlight dimming modes and their count( Min is 1 and Max is tvDimmingMode_MAX). Compare the test results with the platform-supported configurations file 'Sink-4K-TvSettings.yaml' using the path 'DimmingMode/index' and loop through the indices.|
+|Test Group|Module : 02|
+|Test Case ID|011|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Invoke TvInit with no input parameters | None | tvERROR_NONE | Should be successful |
+| 02 | Invoke GetTVSupportedDimmingModes with valid output parameters | dimmingModes = valid buffer, numDimmingModes = valid buffer | tvERROR_NONE | Should be successful |
+| 03 | Compare the number of dimming modes with the platform-supported configurations file | numDimmingModes = value from GetTVSupportedDimmingModes | Equal to the value in 'DimmingMode/index' of 'Sink-4K-TvSettings.yaml' | Should be successful |
+| 04 | Invoke TvTerm with no input parameters | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success: tvERROR_NONE| B[GetTVSupportedDimmingModes]
+    A -->|Failure: Not tvERROR_NONE| A1[Test case fail]
+    B -->|Success: tvERROR_NONE| C[Compare with Sink-4K-TvSettings.yaml]
+    B -->|Failure: Not tvERROR_NONE| B1[Test case fail]
+    C -->|Success: Matched| D[TvTerm]
+    D -->|Success: tvERROR_NONE| E[Test case pass]
+    D -->|Failure: Not tvERROR_NONE| D1[Test case fail]
+```
+
+
+### Test 12
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetDimmingMode`|
+|Description|Set and Gets the TV Dimming modes. The retrieved value should match the set value. Get values are retrieved from the `PQ` database.|
+|Test Group|Module : 02|
+|Test Case ID|12|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Set the TV Dimming mode to "local" using SetTVDimmingMode | dimmingMode = "local" | tvERROR_NONE | Should be successful |
+| 03 | Get the TV Dimming mode using GetTVDimmingMode | getDimmingMode = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Verify the set and get Dimming mode are same | getDimmingMode = "local" | "local" | Should be successful |
+| 05 | Set the TV Dimming mode to "fixed" using SetTVDimmingMode | dimmingMode = "fixed" | tvERROR_NONE | Should be successful |
+| 06 | Get the TV Dimming mode using GetTVDimmingMode | getDimmingMode = valid buffer | tvERROR_NONE | Should be successful |
+| 07 | Verify the set and get Dimming mode are same | getDimmingMode = "fixed" | "fixed" | Should be successful |
+| 08 | Set the TV Dimming mode to "global" using SetTVDimmingMode | dimmingMode = "global" | tvERROR_NONE | Should be successful |
+| 09 | Get the TV Dimming mode using GetTVDimmingMode | getDimmingMode = valid buffer | tvERROR_NONE | Should be successful |
+| 10 | Verify the set and get Dimming mode are same | getDimmingMode = "global" | "global" | Should be successful |
+| 11 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit API Call] -->|Success| B[SetTVDimmingMode API Call with <br> values 'local, fixed, global']
+A -->|Failure| A1[Test Case Fail]
+B -->|Success| D[GetTVDimmingMode API Call]
+B -->|Failure| B1[Test Case Fail]
+D -->|Success| F[Check get and set Dimming Mode]
+D -->|Failure| D1[Test Case Fail]
+F -->|Success| G[TvTerm API Call]
+G -->|Success| H[Test Case Success]
+G -->|Failure| G1[Test Case Fail]
+```
+
+
+### Test 13
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetLocalDimmingLevel`|
+|Description|Set and Gets the local Dimming level. The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|013|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the local dimming level using SetLocalDimmingLevel() for each level in ldimStateLevels[] | ldimStateLevel = LDIM_STATE_NONBOOST, LDIM_STATE_BOOST, LDIM_STATE_BURST | tvERROR_NONE | Should be successful |
+| 03 | Get the local dimming level using GetLocalDimmingLevel() | None | tvERROR_NONE | Should be successful |
+| 04 | Assert that the set and retrieved local dimming levels are equal | None | ldimStateLevel = ldimStateLevelGet | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    TvInit[Call TvInit] -->|tvERROR_NONE| SetLocalDimmingLevel1
+    TvInit -->|Failure| TestcaseFail1[Test case failed]
+    SetLocalDimmingLevel1[Call SetLocalDimmingLevel <br> with LDIM_STATE_NONBOOST,<br> LDIM_STATE_BOOST, LDIM_STATE_BURST] -->|tvERROR_NONE| GetLocalDimmingLevel1
+    SetLocalDimmingLevel1 -->|Failure| TestcaseFail2[Test case failed]
+    GetLocalDimmingLevel1[Call GetLocalDimmingLevel] -->|tvERROR_NONE| Verify1
+    GetLocalDimmingLevel1 -->|Failure| TestcaseFail3[Test case failed]
+    Verify1[Check get matches set value] -->|success| TvTerm
+    TvTerm[Call TvTerm] -->|tvERROR_NONE| TestCaseSuccess[Test case success]
+    TvTerm -->|Failure| TestcaseFail8[Test case failed]
+```
+
+
+### Test 14
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetBrightness`|
+|Description|Set and Gets the brightness within the valid range ( 0 - 100 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|14|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Set the brightness using SetBrightness | brightness = 50 | tvERROR_NONE | Should be successful |
+| 03 | Get the brightness using GetBrightness | get_brightness = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Validate the set and get brightness values are equal | brightness = 50, get_brightness = 50 | Equal | Should be successful |
+| 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    Start(Start) --> Step1[Call TvInit API]
+    Step1 -->|tvERROR_NONE| Step2[Call SetBrightness API with valid value]
+    Step1 -->|Failure| Fail1[Test Case Failed: TvInit API failed]
+    Step2 -->|tvERROR_NONE| Step3[Verify SetBrightness returns tvERROR_NONE]
+    Step2 -->|Failure| Fail2[Test Case Failed: SetBrightness API failed]
+    Step3 -->|Success| Step4[Call GetBrightness API]
+    Step3 -->|Failure| Fail3[Test Case Failed: SetBrightness return value verification failed]
+    Step4 -->|tvERROR_NONE| Step5[Verify GetBrightness returns tvERROR_NONE and value matches]
+    Step4 -->|Failure| Fail4[Test Case Failed: GetBrightness API failed]
+    Step5 -->|Success| Step6[Call TvTerm API]
+    Step5 -->|Failure| Fail5[Test Case Failed: GetBrightness return value verification failed]
+    Step6 -->|tvERROR_NONE| End[Test Case Passed]
+    Step6 -->|Failure| Fail6[Test Case Failed: TvTerm API failed]
+```
+
+
+### Test 15
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetContrast`|
+|Description|Set and Gets the contrast within the valid range ( 0 - 100 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|15|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the contrast using SetContrast() | contrast = 50 | tvERROR_NONE | Should be successful |
+| 03 | Get the contrast using GetContrast() | getContrast = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Check if the set and get contrast values match | contrast = 50, getContrast = retrieved value | tvERROR_NONE, getContrast = contrast | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit API Call] -->|tvERROR_NONE| B[SetContrast API Call]
+A -->|Failure| A1[Test case fail]
+B -->|tvERROR_NONE| C[GetContrast API Call]
+B -->|Failure| B1[Test case fail]
+C -->|tvERROR_NONE and Contrast value matches| D[TvTerm API Call]
+C -->|Failure| C1[Test case fail]
+D -->|tvERROR_NONE| E[Test case success]
+D -->|Failure| D1[Test case fail]
+```
+
+
+### Test 16
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetSharpness`|
+|Description|Set and Gets the sharpness ( 0 - 100 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|16|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the sharpness using SetSharpness() | setSharpness = 50 | tvERROR_NONE | Should be successful |
+| 03 | If SetSharpness() fails, terminate the TV using TvTerm() and exit the test | None | None | Should fail |
+| 04 | Get the sharpness using GetSharpness() | getSharpness = 0 | tvERROR_NONE | Should be successful |
+| 05 | If GetSharpness() fails, terminate the TV using TvTerm() and exit the test | None | None | Should fail |
+| 06 | Assert that the set sharpness and the retrieved sharpness are equal | setSharpness = 50, getSharpness = 50 | True | Should be successful |
+| 07 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit()] -->|Success| B[SetSharpness()]
+A -->|Failure| A1[Test case fail]
+B -->|Success| C[Verify SetSharpness() return status]
+B -->|Failure| B1[Test case fail]
+C -->|Success| D[GetSharpness()]
+C -->|Failure| C1[Test case fail]
+D -->|Success| E[Verify GetSharpness() return status]
+D -->|Failure| D1[Test case fail]
+E -->|Success| F[Verify sharpness value]
+E -->|Failure| E1[Test case fail]
+F -->|Success| G[TvTerm()]
+F -->|Failure| F1[Test case fail]
+G -->|Success| H[Test case success]
+G -->|Failure| G1[Test case fail]
+```
+
+
+### Test 17
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetSaturation`|
+|Description|Set and Gets the saturation within the valid range ( 0 - 100 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|17|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the saturation value using SetSaturation() | saturation_set = 50 | tvERROR_NONE | Should be successful |
+| 03 | Get the saturation value using GetSaturation() | saturation_get = address of variable | tvERROR_NONE | Should be successful |
+| 04 | Compare the set and get saturation values | saturation_set, saturation_get | saturation_set should be equal to saturation_get | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit] -->|Success| B[SetSaturation]
+A -->|Failure| A1[Test case fail: TvInit]
+B -->|Success| C[GetSaturation]
+B -->|Failure| B1[Test case fail: SetSaturation]
+C -->|Success| D[Compare Saturation Value]
+C -->|Failure| C1[Test case fail: GetSaturation]
+D -->|Success| E[TvTerm]
+D -->|Failure| D1[Test case fail: Compare Saturation Value]
+E -->|Success| F[Test case pass]
+E -->|Failure| E1[Test case fail: TvTerm]
+```
+
+
+### Test 18
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetHue`|
+|Description|Set and Gets the Hue ( 0 - 100 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|018|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Hue using SetHue | hue = 50 | tvERROR_NONE | Should be successful |
+| 03 | Get the Hue using GetHue | getHue = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Validate the set and get Hue values are same | hue = 50, getHue = retrieved value | hue should be equal to getHue | Should be successful |
+| 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|tvERROR_NONE| B[SetHue]
+    A -->|Failure| A1[Test case fail]
+    B -->|tvERROR_NONE| C[GetHue]
+    B -->|Failure| B1[Test case fail]
+    C -->|tvERROR_NONE and hue value matches| D[TvTerm]
+    C -->|Failure| C1[Test case fail]
+    D -->|tvERROR_NONE| E[Test case success]
+    D -->|Failure| D1[Test case fail]
+```
+
+
+### Test 19
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetColorTemperature`|
+|Description|Set and Gets the Color Temperature. The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|19|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Set the color temperature using SetColorTemperature | colorTemp = tvColorTemp_STANDARD | tvERROR_NONE | Should be successful |
+| 03 | Get the color temperature using GetColorTemperature | getColorTemp = valid buffer | tvERROR_NONE, colorTemp = getColorTemp | Should be successful |
+| 04 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit API Call] -->|Success| B[SetColorTemperature API Call]
+    A -->|Failure| A1[Test case fail]
+    B -->|Success| C[Verify SetColorTemperature API returns tvERROR_NONE]
+    B -->|Failure| B1[Test case fail]
+    C -->|Success| D[GetColorTemperature API Call]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E[Verify GetColorTemperature API returns tvERROR_NONE and value matches]
+    D -->|Failure| D1[Test case fail]
+    E -->|Success| F[TvTerm API Call]
+    E -->|Failure| E1[Test case fail]
+    F -->|Success| G[Test case success]
+    F -->|Failure| F1[Test case fail]
+```
+
+
+### Test 20
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetAspectRatio`|
+|Description|Set and Gets the Aspect Ratio. The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|20|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Aspect Ratio using SetAspectRatio() with tvDisplayMode_4x3 | setMode = tvDisplayMode_4x3 | tvERROR_NONE | Should be successful |
+| 03 | Get the Aspect Ratio using GetAspectRatio() | getMode = valid buffer | tvERROR_NONE | Should be successful |
+| 04 | Validate the set and get Aspect Ratio are same | setMode, getMode | setMode should be equal to getMode | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B[SetAspectRatio]
+    A -->|Failure| A1[Test case fail: TvInit failed]
+    B -->|Success| C[GetAspectRatio]
+    B -->|Failure| B1[Test case fail: SetAspectRatio failed]
+    C -->|Success| D[Verify GetAspectRatio value]
+    C -->|Failure| C1[Test case fail: GetAspectRatio failed]
+    D -->|Success| E[TvTerm]
+    D -->|Failure| D1[Test case fail: GetAspectRatio value mismatch]
+    E -->|Success| F[Test case pass]
+    E -->|Failure| E1[Test case fail: TvTerm failed]
+```
+
+
+### Test 21
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetLowLatencyState`|
+|Description|Set and Gets the Low Latency State ( 0 for disable and 1 for enable ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|021|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set Low Latency State to 1 using SetLowLatencyState(1) | LowLatencyState = 1 | tvERROR_NONE | Should be successful |
+| 03 | Get Low Latency State using GetLowLatencyState(&lowlatencystate) | lowlatencystate = address of integer variable | tvERROR_NONE, lowlatencystate = 1 | Should be successful |
+| 04 | Set Low Latency State to 0 using SetLowLatencyState(0) | LowLatencyState = 0 | tvERROR_NONE | Should be successful |
+| 05 | Get Low Latency State using GetLowLatencyState(&lowlatencystate) | lowlatencystate = address of integer variable | tvERROR_NONE, lowlatencystate = 0 | Should be successful |
+| 06 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit()] -->|tvERROR_NONE| B[SetLowLatencyState(1)]
+B -->|tvERROR_NONE| C[GetLowLatencyState(&lowlatencystate)]
+C -->|tvERROR_NONE, lowlatencystate=1| D[SetLowLatencyState(0)]
+D -->|tvERROR_NONE| E[GetLowLatencyState(&lowlatencystate)]
+E -->|tvERROR_NONE, lowlatencystate=0| F[TvTerm()]
+A -->|Failure| G[Test case fail]
+B -->|Failure| H[Test case fail]
+C -->|Failure| I[Test case fail]
+D -->|Failure| J[Test case fail]
+E -->|Failure| K[Test case fail]
+F -->|Failure| L[Test case fail]
+```
+
+
+### Test 22
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetDynamicContrast`|
+|Description|Set and Gets the Dynamic Contrast. The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|22|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Set Dynamic Contrast to enabled using SetDynamicContrast | dynamicContrastEnable = "enabled" | tvERROR_NONE | Should be successful |
+| 03 | Get the Dynamic Contrast status using GetDynamicContrast | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, isDynamicContrastEnabled = "enabled" | Should be successful |
+| 04 | Set Dynamic Contrast to disabled using SetDynamicContrast | dynamicContrastEnable = "disabled" | tvERROR_NONE | Should be successful |
+| 05 | Get the Dynamic Contrast status using GetDynamicContrast | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, isDynamicContrastEnabled = "disabled" | Should be successful |
+| 06 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit()] -->|tvERROR_NONE| B[SetDynamicContrast(enabled)]
+B -->|tvERROR_NONE| C[GetDynamicContrast()]
+C -->|tvERROR_NONE, isDynamicContrastEnabled = enabled| D[SetDynamicContrast(disabled)]
+D -->|tvERROR_NONE| E[GetDynamicContrast()]
+E -->|tvERROR_NONE, isDynamicContrastEnabled = disabled| F[TvTerm()]
+A -->|Failure| G[Test case fail]
+B -->|Failure| H[Test case fail]
+C -->|Failure| I[Test case fail]
+D -->|Failure| J[Test case fail]
+E -->|Failure| K[Test case fail]
+F -->|Failure| L[Test case fail]
+```
+
+
+
+### Test 23
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetDynamicGamma`|
+|Description|Set and Gets the Dynamic Gamma within the valid range ( 1.80 to 2.60 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|23|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Dynamic Gamma using SetDynamicGamma() | setGammaValue = 2.0 | tvERROR_NONE | Should be successful |
+| 03 | If SetDynamicGamma() fails, terminate the TV using TvTerm() and return | None | tvERROR_NONE | Should be successful |
+| 04 | Get the Dynamic Gamma using GetDynamicGamma() | getGammaValue = valid buffer | tvERROR_NONE | Should be successful |
+| 05 | Assert that the set and get Gamma values are equal | setGammaValue = 2.0, getGammaValue = retrieved value | setGammaValue should be equal to getGammaValue | Should be successful |
+| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B[SetDynamicGamma]
+    A -->|Failure| A1[Test case fail]
+    B -->|Success| C[GetDynamicGamma]
+    B -->|Failure| B1[Test case fail]
+    C -->|Success| D[Compare GetDynamicGamma value with SetDynamicGamma value]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E[TvTerm]
+    D -->|Failure| D1[Test case fail]
+    E -->|Success| F[Test case success]
+    E -->|Failure| E1[Test case fail]
+```
+
+
+### Test 24
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetSupportedDolbyVisionModes`|
+|Description|Get TV Supported Dolby Vision Modes - Verify the test provides all supported Dolby Vision modes and their count( Min is 0 and Max is tvMode_Max ). Compare the test results with the platform-supported configurations file 'Sink-4K-TvSettings.yaml' using the path 'DolbyVisionMode/index' and loop through the indices.|
+|Test Group|Module : 02|
+|Test Case ID|24|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Invoke GetTVSupportedDolbyVisionModes with valid dvModes and count | dvModes = valid buffer, count = valid buffer | tvERROR_NONE | Should be successful |
+| 03 | Check if the count of supported Dolby Vision modes is between 0 and tvMode_Max | count = returned value from GetTVSupportedDolbyVisionModes | count >= 0 and count <= tvMode_Max | Should be successful |
+| 04 | Loop through the indices and compare the test results with the platform-supported configurations file using the path 'DolbyVisionMode/index' | dvModes[i] = returned value from GetTVSupportedDolbyVisionModes | Equal to the value in the platform-supported configurations file | Should be successful |
+| 05 | Terminate TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit API Call] -->|tvERROR_NONE| B[GetTVSupportedDolbyVisionModes API Call]
+A -->|Failure| A1[Test case fail]
+B -->|tvERROR_NONE| C[Verify count of supported Dolby Vision modes]
+B -->|Failure| B1[Test case fail]
+C -->|0 <= count <= tvMode_Max| D[Loop through array of supported Dolby Vision modes]
+C -->|Failure| C1[Test case fail]
+D --> E[TvTerm API Call]
+E -->|tvERROR_NONE| F[Test case success]
+E -->|Failure| E1[Test case fail]
+```
+
+
+### Test 25
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetDolbyVisionMode`|
+|Description|Set and Gets the TV Dolby Vision mode. The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|025|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Set the TV Dolby Vision mode using SetTVDolbyVisionMode | dolbyMode = tvDolbyMode_Dark | tvERROR_NONE | Should be successful |
+| 03 | Get the TV Dolby Vision mode using GetTVDolbyVisionMode | getDolbyMode = valid buffer | tvERROR_NONE, getDolbyMode = dolbyMode | Should be successful |
+| 04 | If there is a mismatch in set and get Dolby Vision Mode, terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+| 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit()] -->|tvERROR_NONE| B[SetTVDolbyVisionMode()]
+A -->|Failure| A1[Test case fail]
+B -->|tvERROR_NONE| C[GetTVDolbyVisionMode()]
+B -->|Failure| B1[Test case fail]
+C -->|tvERROR_NONE| D[Verify dolbyMode]
+C -->|Failure| C1[Test case fail]
+D -->|Match| E[TvTerm()]
+D -->|Mismatch| D1[Test case fail]
+E -->|tvERROR_NONE| F[Test case pass]
+E -->|Failure| E1[Test case fail]
+```
+
+
+### Test 26
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetTVSupportedPictureModes`|
+|Description|Get TV Supported Picture Modes - Verify the test provides all supported Picture Modes and their count( Min is 1 and Max is PIC_MODES_SUPPORTED_MAX ). Compare the test results with the platform-supported configurations file 'Sink-4K-TvSettings.yaml' using the path 'PictureMode/index' and loop through the indices.|
+|Test Group|Module : 02|
+|Test Case ID|26|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit | No input parameters | tvERROR_NONE | Should be successful |
+| 02 | Get supported picture modes and their count using GetTVSupportedPictureModes | pictureModes = valid buffer, count = valid buffer | status not equal to tvERROR_INVALID_PARAM and tvERROR_INVALID_STATE, count between 1 and PIC_MODES_SUPPORTED_MAX | Should be successful |
+| 03 | Loop through the picture modes and compare with the platform-supported configurations file | pictureModes[i]->name = "PictureMode/index" | Equal to profile string | Should be successful |
+| 04 | Terminate TV using TvTerm | No input parameters | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit()] -->|tvERROR_NONE| B[GetTVSupportedPictureModes()]
+    A -->|!= tvERROR_NONE| C[Test case fail]
+    B -->|!= tvERROR_INVALID_PARAM, != tvERROR_INVALID_STATE| D[Check count of picture modes]
+    B -->|== tvERROR_INVALID_PARAM or == tvERROR_INVALID_STATE| E[Test case fail]
+    D -->|1 <= count <= PIC_MODES_SUPPORTED_MAX| F[Compare picture modes with Sink-4K-TvSettings.yaml]
+    D -->|count < 1 or count > PIC_MODES_SUPPORTED_MAX| G[Test case fail]
+    F -->|Match| H[Loop through picture modes]
+    F -->|No Match| I[Test case fail]
+    H --> J[TvTerm()]
+    J -->|tvERROR_NONE| K[Test case pass]
+    J -->|!= tvERROR_NONE| L[Test case fail]
+```
+
+
+### Test 27
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetPictureMode`|
+|Description|Set and Gets the TV Picture Mode. The retrieved value should match the set value. Set the picture mode to a valid value as specified by ::pic_modes_t.name from the GetTVSupportedPictureModes API, with the string size limited to PIC_MODE_NAME_MAX. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|27|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Get supported picture modes using GetTVSupportedPictureModes() | pictureModes = valid buffer, count = valid buffer | tvERROR_NONE | Should be successful |
+| 03 | Set TV picture mode using SetTVPictureMode() for each supported mode | pictureMode = pictureModes[i]->name | tvERROR_NONE | Should be successful |
+| 04 | Get TV picture mode using GetTVPictureMode() after setting each mode | pictureMode = valid buffer | tvERROR_NONE | Should be successful |
+| 05 | Validate the set and get picture modes are same | pictureModes[i]->name, pictureMode | Equal | Should be successful |
+| 06 | Terminate TV using TvTerm() after each set and get operation | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit()] -->|tvERROR_NONE| B[Declare pic_modes_t array and unsigned short variable]
+B -->|tvERROR_NONE| C[GetTVSupportedPictureModes()]
+C -->|tvERROR_NONE, 1 <= count <= PIC_MODES_SUPPORTED_MAX| D[Choose a valid picture mode]
+D -->|Valid picture mode chosen| E[SetTVPictureMode()]
+E -->|tvERROR_NONE| F[Declare char array of size PIC_MODE_NAME_MAX]
+F -->|Array declared| G[GetTVPictureMode()]
+G -->|tvERROR_NONE, returned picture mode matches set picture mode| H[TvTerm()]
+H -->|tvERROR_NONE| I[Test case pass]
+A -->|!=tvERROR_NONE| J[Test case fail]
+B -->|!=tvERROR_NONE| K[Test case fail]
+C -->|!=tvERROR_NONE or count < 1 or count > PIC_MODES_SUPPORTED_MAX| L[Test case fail]
+D -->|Invalid picture mode chosen| M[Test case fail]
+E -->|!=tvERROR_NONE| N[Test case fail]
+F -->|Array declaration failed| O[Test case fail]
+G -->|!=tvERROR_NONE or returned picture mode doesn't match set picture mode| P[Test case fail]
+H -->|!=tvERROR_NONE| Q[Test case fail]
+```
+
+
+
+### Test 28
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetColorTempRgain`|
+|Description|Loop through different color temperatures and source ids. Set and Gets the color Temperature Rgain on Source. The retrieved value should match the set value. Get values are retrieved from the  database.|
+|Test Group|Module : 02|
+|Test Case ID|28|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Loop through different color temperatures and source ids | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX, sourceId = ALL_SRC_OFFSET to MAX_OFFSET | None | None |
+| 03 | Set the color Temperature Rgain on Source using SetColorTemp_Rgain_onSource | colorTemp = current colorTemp, setRgain = 0 to 2047, sourceId = current sourceId, saveOnly = 0 | tvERROR_NONE | Should be successful |
+| 04 | Get the color Temperature Rgain on Source using GetColorTemp_Rgain_onSource | colorTemp = current colorTemp, rgain = address of rgain, sourceId = current sourceId | tvERROR_NONE | Should be successful |
+| 05 | Check if the retrieved rgain matches the set rgain | rgain = retrieved rgain, setRgain = set rgain | rgain should be equal to setRgain | Should be successful |
+| 06 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A -->|Failure| A1[Test case fail]
+    B -->|Next Combination| C[SetColorTemp_Rgain_onSource with rgain value and saveOnly parameter as 0]
+    B -->|End of Loop| G[TvTerm]
+    C -->|Success| D[GetColorTemp_Rgain_onSource]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E{Verify rgain value}
+    D -->|Failure| D1[Test case fail]
+    E -->|Match| B
+    E -->|Mismatch| E1[Test case fail]
+    G -->|Success| H[Test case pass]
+    G -->|Failure| G1[Test case fail]
+```
+
+
+
+### Test 29
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetColorTempGgain`|
+|Description|Loop through different color temperatures and source ids. Set and Gets the color Temperature Ggain on Source. The retrieved value should match the set value. Get values are retrieved from the  database.|
+|Test Group|Module : 02|
+|Test Case ID|29|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Loop through different color temperatures and source ids | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX, sourceId = ALL_SRC_OFFSET to MAX_OFFSET | None | Should be successful |
+| 03 | Set the color Temperature Ggain on Source using SetColorTemp_Ggain_onSource | colorTemp = current colorTemp, set_ggain = 0 to 2047, sourceId = current sourceId, saveOnly = 0 | tvERROR_NONE | Should be successful |
+| 04 | Get the color Temperature Ggain on Source using GetColorTemp_Ggain_onSource | colorTemp = current colorTemp, ggain = address of ggain, sourceId = current sourceId | tvERROR_NONE | Should be successful |
+| 05 | Check if the retrieved ggain matches the set ggain | ggain = retrieved ggain, set_ggain = set ggain | ggain should be equal to set_ggain | Should be successful |
+| 06 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A -->|Failure| A1[Test case fail]
+    B -->|Next Combination| C[SetColorTemp_Ggain_onSource with ggain value and saveOnly parameter as 0]
+    B -->|End of Loop| G[TvTerm]
+    C -->|Success| D[GetColorTemp_Ggain_onSource]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E{Verify ggain value}
+    D -->|Failure| D1[Test case fail]
+    E -->|Match| B
+    E -->|Mismatch| E1[Test case fail]
+    G -->|Success| H[Test case pass]
+    G -->|Failure| G1[Test case fail]
+```
+
+
+### Test 30
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetColorTempBgain`|
+|Description|Loop through different color temperatures and source ids. Set and Gets the color Temperature Bgain on Source. The retrieved value should match the set value. Get values are retrieved from the  database.|
+|Test Group|Module : 02|
+|Test Case ID|30|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Loop through different color temperatures and source ids | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX, sourceId = ALL_SRC_OFFSET to MAX_OFFSET | None | Should be successful |
+| 03 | Set the color Temperature Bgain on Source using SetColorTemp_Bgain_onSource | colorTemp, bgain = 0 to 2047, sourceId, saveOnly = 0 | tvERROR_NONE | Should be successful |
+| 04 | Get the color Temperature Bgain on Source using GetColorTemp_Bgain_onSource | colorTemp, &get_bgain, sourceId | tvERROR_NONE | Should be successful |
+| 05 | Check if the retrieved value matches the set value | bgain, get_bgain | bgain should be equal to get_bgain | Should be successful |
+| 06 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A -->|Failure| A1[Test case fail]
+    B -->|Next Combination| C[SetColorTemp_Bgain_onSource]
+    B -->|All Combinations Done| G[TvTerm]
+    C -->|Success| D[GetColorTemp_Bgain_onSource]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E{Verify bgain value}
+    D -->|Failure| D1[Test case fail]
+    E -->|Match| B
+    E -->|Mismatch| E1[Test case fail]
+    G -->|Success| H[Test case pass]
+    G -->|Failure| G1[Test case fail]
+```
+
+
+
+###Test 31
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetColorTemp_R_post_offset_onSource`|
+|Description|Loop through different color temperatures and source ids. Set and Gets the color Temperature R post offset on Source. The retrieved value should match the set value. Get values are retrieved from the  database.|
+|Test Group|Module : 02|
+|Test Case ID|031|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Loop through different color temperatures and source ids. Set the color Temperature R post offset on Source using SetColorTemp_R_post_offset_onSource | colorTemp = value, rpostoffset_set = value, sourceId = value, saveOnly = value | tvERROR_NONE | Should be successful |
+| 03 | Get the color Temperature R post offset on Source using GetColorTemp_R_post_offset_onSource | colorTemp = value, sourceId = value | tvERROR_NONE | Should be successful |
+| 04 | Check if the retrieved value matches the set value | rpostoffset_set = value, rpostoffset_get = value | rpostoffset_set should be equal to rpostoffset_get | Should be successful |
+| 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit()] -->|Success| B{Loop through color temperatures and source ids}
+    A -->|Failure| A1[Test case fail]
+    B -->|Next Combination| C[SetColorTemp_R_post_offset_onSource() with saveOnly=0]
+    B -->|End of Loop| G[TvTerm()]
+    C -->|Success| D[GetColorTemp_R_post_offset_onSource()]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E{Compare set and retrieved rpostoffset values}
+    D -->|Failure| D1[Test case fail]
+    E -->|Match| B
+    E -->|Mismatch| E1[Test case fail]
+    G -->|Success| H[Test case pass]
+    G -->|Failure| G1[Test case fail]
+    B --> F[SetColorTemp_R_post_offset_onSource() with saveOnly=1]
+    F -->|Success| I[GetColorTemp_R_post_offset_onSource()]
+    F -->|Failure| F1[Test case fail]
+    I -->|Success| J{Compare set and retrieved rpostoffset values}
+    I -->|Failure| I1[Test case fail]
+    J -->|Match| B
+    J -->|Mismatch| J1[Test case fail]
+```
+
+
+### Test 32
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetColorTempGPostOffset`|
+|Description|Loop through different color temperatures and source ids. Set and Gets the color Temperature G post offset on Source. The retrieved value should match the set value. Get values are retrieved from the  database.|
+|Test Group|Module : 02|
+|Test Case ID|32|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Loop through different color temperatures and source ids | colorTemp = tvColorTemp_STANDARD to tvColorTemp_MAX, sourceId = ALL_SRC_OFFSET to MAX_OFFSET | None | None |
+| 03 | Set the color Temperature G post offset on Source using SetColorTemp_G_post_offset_onSource() | colorTemp, gpostoffset_set = -1024 to 1023, sourceId, saveOnly = 0 | tvERROR_NONE | Should be successful |
+| 04 | Get the color Temperature G post offset on Source using GetColorTemp_G_post_offset_onSource() | colorTemp, &gpostoffset_get, sourceId | tvERROR_NONE, gpostoffset_set | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A -->|Failure| A1[Test case fail]
+    B -->|Next Combination| C[SetColorTemp_G_post_offset_onSource]
+    B -->|End of Loop| G[TvTerm]
+    C -->|Success| D[GetColorTemp_G_post_offset_onSource]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| B
+    D -->|Failure| D1[Test case fail]
+    G -->|Success| H[Test case pass]
+    G -->|Failure| G1[Test case fail]
+```
+
+
+### Test 33
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetColorTempBPostOffset`|
+|Description|Loop through different color temperatures and source ids. Set and Gets the color Temperature B post offset on Source. The retrieved value should match the set value. Get values are retrieved from the  database.|
+|Test Group|Module : 02|
+|Test Case ID|033|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Loop through different color temperatures and source ids. Set the color Temperature B post offset on Source using SetColorTemp_B_post_offset_onSource | colorTemp = value, bpostoffset_set = value, sourceId = value, saveOnly = 1 | tvERROR_NONE | Should be successful |
+| 03 | Get the color Temperature B post offset on Source using GetColorTemp_B_post_offset_onSource | colorTemp = value, sourceId = value | tvERROR_NONE | Should be successful |
+| 04 | Check if the retrieved value matches the set value | bpostoffset_set = value, bpostoffset_get = value | bpostoffset_set should be equal to bpostoffset_get | Should be successful |
+| 05 | Terminate the TV using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B{Loop through color temperatures and source ids}
+    A -->|Failure| A1[Test case fail]
+    B -->|Next Combination| C[SetColorTemp_B_post_offset_onSource]
+    B -->|End of Loop| G[TvTerm]
+    C -->|Success| D[GetColorTemp_B_post_offset_onSource]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E{Compare set and retrieved bpostoffset}
+    D -->|Failure| D1[Test case fail]
+    E -->|Match| B
+    E -->|Mismatch| E1[Test case fail]
+    G -->|Success| H[Test case pass]
+    G -->|Failure| G1[Test case fail]
+```
+
+
+### Test 34
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_DisableAndVerifyWBCalibrationMode`|
+|Description|Disables the `WB` Calibration Mode and verify by the Get Current WB Calibration Mode|
+|Test Group|Module : 02|
+|Test Case ID|034|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Disable the WB Calibration Mode using EnableWBCalibrationMode() | false | tvERROR_NONE | Should be successful |
+| 03 | Get the current WB Calibration Mode using GetCurrentWBCalibrationMode() | &value | tvERROR_NONE, false | Should be successful |
+| 04 | If the status is not tvERROR_NONE or value is not false, terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    Start(Start) --> Step1
+    Step1{Call TvInit API} -->|tvERROR_NONE| Step2
+    Step1 -->|Failure| TestcaseFail1[Test case 34 failed]
+    Step2{Call EnableWBCalibrationMode API with false} -->|tvERROR_NONE| Step3
+    Step2 -->|Failure| TestcaseFail2[Test case 34 failed]
+    Step3{Call GetCurrentWBCalibrationMode API} -->|tvERROR_NONE and output is false| Step4
+    Step3 -->|Failure| TestcaseFail3[Test case 34 failed]
+    Step4{Call TvTerm API} -->|tvERROR_NONE| End(End)
+    Step4 -->|Failure| TestcaseFail4[Test case 34 failed]
+```
+
+
+### Test 35
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_EnableAndVerifyWBCalibrationMode`|
+|Description|Enables the `WB` Calibration Mode and verify by the Get Current WB Calibration Mode|
+|Test Group|Module : 02|
+|Test Case ID|35|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Enable WB Calibration Mode using EnableWBCalibrationMode() | value = true | tvERROR_NONE | Should be successful |
+| 03 | Get the current WB Calibration Mode using GetCurrentWBCalibrationMode() | value = address of bool variable | tvERROR_NONE, value = true | Should be successful |
+| 04 | Disable WB Calibration Mode using EnableWBCalibrationMode() | value = false | tvERROR_NONE | Should be successful |
+| 05 | Get the current WB Calibration Mode using GetCurrentWBCalibrationMode() | value = address of bool variable | tvERROR_NONE, value = false | Should be successful |
+| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit()] -->|tvERROR_NONE| B[EnableWBCalibrationMode(true)]
+    A -->|!=tvERROR_NONE| A1[Test case fail]
+    B -->|tvERROR_NONE| C[GetCurrentWBCalibrationMode()]
+    B -->|!=tvERROR_NONE| B1[Test case fail]
+    C -->|tvERROR_NONE, output=true| D[EnableWBCalibrationMode(false)]
+    C -->|!=tvERROR_NONE or output!=true| C1[Test case fail]
+    D -->|tvERROR_NONE| E[GetCurrentWBCalibrationMode()]
+    D -->|!=tvERROR_NONE| D1[Test case fail]
+    E -->|tvERROR_NONE, output=false| F[TvTerm()]
+    E -->|!=tvERROR_NONE or output!=false| E1[Test case fail]
+    F -->|tvERROR_NONE| G[Test case pass]
+    F -->|!=tvERROR_NONE| F1[Test case fail]
+```
+
+
+
+### Test 36
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetGammaTable`|
+|Description|Set and Gets the Gamma Table within the range ( 0 - 1023). The retrieved value should match the set value. Get values are retrieved from the  database.|
+|Test Group|Module : 02|
+|Test Case ID|36|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Gamma Table using SetGammaTable() with valid buffers | pData_R = valid buffer, pData_G = valid buffer, pData_B = valid buffer, size = 256 | tvERROR_NONE | Should be successful |
+| 03 | If SetGammaTable() fails, terminate the TV using TvTerm() and return | None | None | Should fail |
+| 04 | Get the Gamma Table using GetGammaTable() with valid buffers | getData_R = valid buffer, getData_G = valid buffer, getData_B = valid buffer, size = 256 | tvERROR_NONE | Should be successful |
+| 05 | Compare the set and get values for each color | pData_R[i] = getData_R[i], pData_G[i] = getData_G[i], pData_B[i] = getData_B[i] | pData_R[i] = getData_R[i], pData_G[i] = getData_G[i], pData_B[i] = getData_B[i] | Should be successful |
+| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B[Create three arrays of unsigned short values]
+    A -->|Failure| A1[Test case fail]
+    B -->|Success| C[SetGammaTable]
+    B -->|Failure| B1[Test case fail]
+    C -->|Success| D[GetGammaTable]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E[Compare values]
+    D -->|Failure| D1[Test case fail]
+    E -->|Success| F[TvTerm]
+    E -->|Failure| E1[Test case fail]
+    F -->|Success| G[Test case pass]
+    F -->|Failure| F1[Test case fail]
+```
+
+
+### Test 37
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetDefaultGammaTable`|
+|Description|Gets the default gamma calibrated values for gamma red, green and blue values ( 0 - 65535 ) and check the values are in the range.|
+|Test Group|Module : 02|
+|Test Case ID|37|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV settings using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Get the default gamma table for standard color temperature using GetDefaultGammaTable() | colortemp = tvColorTemp_STANDARD, pData_R = valid array, pData_G = valid array, pData_B = valid array, size = 256 | tvERROR_NONE | Should be successful |
+| 03 | Check if the returned gamma values for red, green and blue are in the range 0 - 65535 | pData_R = valid array, pData_G = valid array, pData_B = valid array | None | Should be successful |
+| 04 | Terminate the TV settings using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit is called] -->|Return status is tvERROR_NONE| B[GetDefaultGammaTable is called with valid color temperature and arrays]
+A -->|Return status is not tvERROR_NONE| A1[Test case 37 fails]
+B -->|Return status is tvERROR_NONE| C[Check values in pData_R, pData_G, and pData_B arrays]
+B -->|Return status is not tvERROR_NONE| B1[Test case 37 fails]
+C -->|Values are within valid range| D[TvTerm is called]
+C -->|Values are not within valid range| C1[Test case 37 fails]
+D -->|Return status is tvERROR_NONE| E[Test case 37 passes]
+D -->|Return status is not tvERROR_NONE| D1[Test case 37 fails]
+```
+
+
+### Test 38
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetDvTmaxValue`|
+|Description|Set and Gets the Dv Tmax Value within the range ( 0 - 10000 ). The retrieved value should match the set value. Get values are retrieved from the  database.|
+|Test Group|Module : 02|
+|Test Case ID|38|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV settings using TvInit | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Dv Tmax Value using SetDvTmaxValue | setValue = 5000 | tvERROR_NONE | Should be successful |
+| 03 | If SetDvTmaxValue fails, terminate the TV settings using TvTerm and return | None | None | Should be successful |
+| 04 | Get the Dv Tmax Value using GetDvTmaxValue | getValue = address of integer variable | tvERROR_NONE | Should be successful |
+| 05 | If GetDvTmaxValue fails, terminate the TV settings using TvTerm and return | None | None | Should be successful |
+| 06 | Assert that the set value and the retrieved value are equal | setValue = 5000, getValue = retrieved value | setValue should be equal to getValue | Should be successful |
+| 07 | Terminate the TV settings using TvTerm | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    Start(Start) --> Step1
+    Step1{Call TvInit API} -->|Success| Step2
+    Step1 -->|Failure| TestcaseFail1[Test case 38: Fail]
+    Step2{Call SetDvTmaxValue API with value in range 0 to 10000} -->|Success| Step3
+    Step2 -->|Failure| TestcaseFail2[Test case 38: Fail]
+    Step3{Call GetDvTmaxValue API} -->|Success| Step4
+    Step3 -->|Failure| TestcaseFail3[Test case 38: Fail]
+    Step4{Verify retrieved value matches set value} -->|Success| Step5
+    Step4 -->|Failure| TestcaseFail4[Test case 38: Fail]
+    Step5{Call TvTerm API} -->|Success| End(End)
+    Step5 -->|Failure| TestcaseFail5[Test case 38: Fail]
+```
+
+
+### Test 39
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetSupportedComponentColor`|
+|Description|Verifies whether the test gets the supported component colors by comparing the test results with the platform-supported configurations file 'Sink-4K-TvSettings.yaml' using the path 'SupportedComponentColor' and loop through the indices.|
+|Test Group|Module : 02|
+|Test Case ID|039|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Invoke GetSupportedComponentColor() with valid address | blComponentColor = valid address | tvERROR_NONE | Should be successful |
+| 03 | Compare the returned value with the value in the platform-supported configurations file | blComponentColor, "SupportedComponentColor" | Equal values | Should be successful |
+| 04 | Loop through the indices of the returned value and check if the component color at each index is supported | blComponentColor = returned value | None | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|tvERROR_NONE| B[Declare integer variable]
+    A -->|Failure| A1[Test case fail]
+    B --> C[GetSupportedComponentColor]
+    B -->|Failure| B1[Test case fail]
+    C -->|tvERROR_NONE| D[Compare with Sink-4K-TvSettings.yaml]
+    C -->|Failure| C1[Test case fail]
+    D --> E[Loop through indices]
+    D -->|Failure| D1[Test case fail]
+    E --> F[TvTerm]
+    F -->|tvERROR_NONE| G[Test case pass]
+    F -->|Failure| F1[Test case fail]
+```
+
+
+### Test 40
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetComponentSaturation`|
+|Description|Set and Get the component saturation by verifying whether the values are within the valid range (0 - 100). The retrieved value should match the set value. Get values are fetched from the  database.|
+|Test Group|Module : 02|
+|Test Case ID|40|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the CMS state to true using SetCMSState() | state = true | tvERROR_NONE | Should be successful |
+| 03 | For each color component, set a random saturation value between 0 and 100 using SetCurrentComponentSaturation() | color = color component, saturation = random value between 0 and 100 | tvERROR_NONE | Should be successful |
+| 04 | Get the current component saturation using GetCurrentComponentSaturation() | color = color component, saturation = pointer to saturation variable | tvERROR_NONE | Should be successful |
+| 05 | Assert that the set saturation value matches the retrieved saturation value | setSaturation = set value, saturation = retrieved value | setSaturation should be equal to saturation | Should be successful |
+| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B[SetCMSState(true)]
+    B -->|Success| C[SetCurrentComponentSaturation(color, saturation)]
+    C -->|Success| D[GetCurrentComponentSaturation(color)]
+    D -->|Success, Saturation matches| E[SetCurrentComponentSaturation(next color, saturation)]
+    E -->|Success| F[GetCurrentComponentSaturation(next color)]
+    F -->|Success, Saturation matches| G[SetCurrentComponentSaturation(next color, saturation)]
+    G -->|Success| H[GetCurrentComponentSaturation(next color)]
+    H -->|Success, Saturation matches| I[TvTerm]
+    A -->|Failure| J[Test case fail]
+    B -->|Failure| K[Test case fail]
+    C -->|Failure| L[Test case fail]
+    D -->|Failure, Saturation doesn't match| M[Test case fail]
+    E -->|Failure| N[Test case fail]
+    F -->|Failure, Saturation doesn't match| O[Test case fail]
+    G -->|Failure| P[Test case fail]
+    H -->|Failure, Saturation doesn't match| Q[Test case fail]
+    I -->|Failure| R[Test case fail]
+```
+
+
+### Test 41
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetComponentHue`|
+|Description|Set and Get the Component Hue by verifying whether the values are within the valid range (0 - 100). The retrieved value should match the set value. Get values are fetched from the database.|
+|Test Group|Module : 02|
+|Test Case ID|041|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set CMS state to true using SetCMSState() | state = true | tvERROR_NONE | Should be successful |
+| 03 | Loop through each color and hue value. Set the current component hue using SetCurrentComponentHue() | color = tvDataColor_RED to tvDataColor_MAX, hue = 0 to 100 | tvERROR_NONE | Should be successful |
+| 04 | Get the current component hue using GetCurrentComponentHue() | color = tvDataColor_RED to tvDataColor_MAX | tvERROR_NONE, hue value should match the set value | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|Success| B[SetCMSState(true)]
+    B -->|Success| C[SetCurrentComponentHue(color, hue)]
+    B -->|Failure| Bf[Test case fail]
+    C -->|Success| D[Verify SetCurrentComponentHue returns tvERROR_NONE]
+    C -->|Failure| Cf[Test case fail]
+    D -->|Success| E[GetCurrentComponentHue(color)]
+    D -->|Failure| Df[Test case fail]
+    E -->|Success| F[Verify GetCurrentComponentHue returns tvERROR_NONE and hue matches]
+    E -->|Failure| Ef[Test case fail]
+    F -->|Success| G[Repeat for all colors]
+    F -->|Failure| Ff[Test case fail]
+    G --> H[TvTerm]
+    H -->|Success| I[Test case success]
+    H -->|Failure| Hf[Test case fail]
+```
+
+
+
+### Test 42
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetComponentLuma`|
+|Description|Set and Gets the Component Luma by verifying whether the values are within the valid range (0 - 100). The retrieved value should match the set value. Get values are fetched from the database.|
+|Test Group|Module : 02|
+|Test Case ID|042|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set CMS state to true using SetCMSState() | state = true | tvERROR_NONE | Should be successful |
+| 03 | Loop through each color component. Set the luma value for the current color component using SetCurrentComponentLuma() | color = color component, lumaSet = 15 | tvERROR_NONE | Should be successful |
+| 04 | Get the luma value for the current color component using GetCurrentComponentLuma() | color = color component | tvERROR_NONE, luma = lumaSet | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+A[TvInit()] -->|Success| B[SetCMSState(true)]
+A -->|Failure| A1[Test case fail]
+B -->|Success| C[For each color in tvDataComponentColor_t]
+B -->|Failure| B1[Test case fail]
+C --> D[SetCurrentComponentLuma(color, luma)]
+D -->|Success| E[Verify return value is tvERROR_NONE]
+D -->|Failure| D1[Test case fail]
+E --> F[GetCurrentComponentLuma(color)]
+F -->|Success| G[Verify return value is tvERROR_NONE]
+F -->|Failure| F1[Test case fail]
+G --> H[Verify luma value matches set value]
+H --> C
+C --> I[TvTerm()]
+I -->|Success| J[Test case pass]
+I -->|Failure| I1[Test case fail]
+```
+
+
+### Test 43
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetCMSState`|
+|Description|Set and Gets the `CMS` State. The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|43|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the CMS state to true using SetCMSState() | enableCMSState = true | tvERROR_NONE | Should be successful |
+| 03 | Get the CMS state using GetCMSState() | enableCMSState = address of enableCMSState variable | tvERROR_NONE, enableCMSState = true | Should be successful |
+| 04 | Set the CMS state to false using SetCMSState() | enableCMSState = false | tvERROR_NONE | Should be successful |
+| 05 | Get the CMS state using GetCMSState() | enableCMSState = address of enableCMSState variable | tvERROR_NONE, enableCMSState = false | Should be successful |
+| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    Start(Start) --> Step1
+    Step1{Call TvInit API} -->|tvERROR_NONE| Step2
+    Step1 -->|Failure| TestcaseFail1[Test case 43 fail]
+    Step2{Call SetCMSState API with true} -->|tvERROR_NONE| Step3
+    Step2 -->|Failure| TestcaseFail2[Test case 43 fail]
+    Step3{Call GetCMSState API, check true} -->|Success| Step4
+    Step3 -->|Failure| TestcaseFail3[Test case 43 fail]
+    Step4{Call SetCMSState API with false} -->|tvERROR_NONE| Step5
+    Step4 -->|Failure| TestcaseFail4[Test case 43 fail]
+    Step5{Call GetCMSState API, check false} -->|Success| Step6
+    Step5 -->|Failure| TestcaseFail5[Test case 43 fail]
+    Step6{Call TvTerm API} -->|tvERROR_NONE| End(End)
+    Step6 -->|Failure| TestcaseFail6[Test case 43 fail]
+```
+
+
+### Test 44
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_TestGetPQParameters`|
+|Description|To test the Get `PQ` Parameters, loop through the different video sources, video formats, and picture quality modes for all combinations and set the brightness, contrast, sharpness, and component saturation value (loop through different saturation colors) to 50%. For Tmax, set the value to 500, and for low latency, set it to 1. After setting these values, loop through the different video sources, video formats, and picture quality modes again, read back the GetPQ parameter values and ensure that all are set to the required values: brightness, contrast, sharpness, and component saturation at 50%, Tmax at 500, and low latency at 1.|
+|Test Group|Module : 02|
+|Test Case ID|044|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Loop through video sources, video formats, and PQ modes. Set brightness, contrast, saturation, hue, component saturation, Tmax value, and low latency state using respective APIs | videoSrcType = VIDEO_SOURCE_ANALOGUE to VIDEO_SOURCE_MAX, videoFormatType = VIDEO_FORMAT_NONE to VIDEO_FORMAT_MAX, pq_mode = 0 to PQ_MODE_MAX, value = 50 for brightness, contrast, saturation, hue, and component saturation, value = 500 for Tmax, value = 1 for low latency state | tvERROR_NONE | Should be successful |
+| 03 | Loop through video sources, video formats, and PQ modes again. Get PQ parameters using GetPQParams() and verify the values | videoSrcType = VIDEO_SOURCE_ANALOGUE to VIDEO_SOURCE_MAX, videoFormatType = VIDEO_FORMAT_NONE to VIDEO_FORMAT_MAX, pq_mode = 0 to PQ_MODE_MAX, pqParamIndex = PQ_PARAM_BRIGHTNESS to PQ_PARAM_MAX | tvERROR_NONE, value = 50 for brightness, contrast, saturation, hue, and component saturation, value = 500 for Tmax, value = 1 for low latency state | Should be successful |
+| 04 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit()] -->|Success| B{Loop through video sources, formats, PQ modes}
+    A -->|Failure| A1[Test case fail]
+    B -->|Success| C[SaveBrightness(), SaveContrast(), SaveSaturation(), SaveHue()]
+    B -->|Failure| B1[Test case fail]
+    C -->|Success| D[SetCurrentComponentSaturation()]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E[SaveDvTmaxValue()]
+    D -->|Failure| D1[Test case fail]
+    E -->|Success| F[SaveLowLatencyState()]
+    E -->|Failure| E1[Test case fail]
+    F -->|Success| G{Loop through video sources, formats, PQ modes}
+    F -->|Failure| F1[Test case fail]
+    G -->|Success| H[GetPQParams()]
+    G -->|Failure| G1[Test case fail]
+    H -->|Success| I[TvTerm()]
+    H -->|Failure| H1[Test case fail]
+    I -->|Success| J[Test case success]
+    I -->|Failure| I1[Test case fail]
+```
+
+
+### Test 45
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_GetTVGammaTarget`|
+|Description|Get TV Gamma Target verifies the functionality of retrieving the target x and y coordinates for the panel gamma based on a given color temperature. It ensures that the returned coordinates are within the range of 0 to 1.0. Validate with various color temperatures (tvColorTemp_t).|
+|Test Group|Module : 02|
+|Test Case ID|045|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Loop through each color temperature in tvColorTemp_t and retrieve the target x and y coordinates for the panel gamma using GetTVGammaTarget() | colorTemp = tvColorTemp_STANDARD, tvColorTemp_WARM, tvColorTemp_COLD, tvColorTemp_USER, tvColorTemp_BOOST_STANDARD, tvColorTemp_BOOST_WARM, tvColorTemp_BOOST_COLD, tvColorTemp_BOOST_USER, tvColorTemp_SUPERCOLD, tvColorTemp_BOOST_SUPERCOLD | x and y coordinates should be within the range of 0 to 1.0 | Should be successful |
+| 03 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    Start(Start) --> TvInit
+    TvInit{Call TvInit API} -->|Return status is tvERROR_NONE| GetTVGammaTarget1
+    TvInit -->|Return status is not tvERROR_NONE| TestcaseFail1[Test case fail]
+    GetTVGammaTarget1{Call GetTVGammaTarget API with tvColorTemp_STANDARD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget2
+    GetTVGammaTarget1 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail2[Test case fail]
+    GetTVGammaTarget2{Call GetTVGammaTarget API with tvColorTemp_WARM} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget3
+    GetTVGammaTarget2 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail3[Test case fail]
+    GetTVGammaTarget3{Call GetTVGammaTarget API with tvColorTemp_COLD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget4
+    GetTVGammaTarget3 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail4[Test case fail]
+    GetTVGammaTarget4{Call GetTVGammaTarget API with tvColorTemp_USER} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget5
+    GetTVGammaTarget4 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail5[Test case fail]
+    GetTVGammaTarget5{Call GetTVGammaTarget API with tvColorTemp_BOOST_STANDARD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget6
+    GetTVGammaTarget5 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail6[Test case fail]
+    GetTVGammaTarget6{Call GetTVGammaTarget API with tvColorTemp_BOOST_WARM} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget7
+    GetTVGammaTarget6 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail7[Test case fail]
+    GetTVGammaTarget7{Call GetTVGammaTarget API with tvColorTemp_BOOST_COLD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget8
+    GetTVGammaTarget7 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail8[Test case fail]
+    GetTVGammaTarget8{Call GetTVGammaTarget API with tvColorTemp_BOOST_USER} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget9
+    GetTVGammaTarget8 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail9[Test case fail]
+    GetTVGammaTarget9{Call GetTVGammaTarget API with tvColorTemp_SUPERCOLD} -->|x and y coordinates are within 0 to 1.0| GetTVGammaTarget10
+    GetTVGammaTarget9 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail10[Test case fail]
+    GetTVGammaTarget10{Call GetTVGammaTarget API with tvColorTemp_BOOST_SUPERCOLD} -->|x and y coordinates are within 0 to 1.0| TvTerm
+    GetTVGammaTarget10 -->|x and y coordinates are not within 0 to 1.0| TestcaseFail11[Test case fail]
+    TvTerm{Call TvTerm API} -->|Return status is tvERROR_NONE| End(End)
+    TvTerm -->|Return status is not tvERROR_NONE| TestcaseFail12[Test case fail]
+```
+
+
+### Test 46
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetRGBPattern`|
+|Description|Set and Gets the RGB Pattern within the range ( 0 - 255 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|46|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the RGB pattern using SetRGBPattern() | r_set = 100, g_set = 150, b_set = 200 | tvERROR_NONE | Should be successful |
+| 03 | Get the RGB pattern using GetRGBPattern() | r_get, g_get, b_get | tvERROR_NONE | Should be successful |
+| 04 | Check if the retrieved RGB values match the set values | r_get, g_get, b_get | r_set, g_set, b_set | Should be successful |
+| 05 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit()] -->|Success| B[SetRGBPattern()]
+    A -->|Failure| A1[Test case fail]
+    B -->|Success| C[Verify SetRGBPattern() returns tvERROR_NONE]
+    B -->|Failure| B1[Test case fail]
+    C -->|Success| D[GetRGBPattern()]
+    C -->|Failure| C1[Test case fail]
+    D -->|Success| E[Verify GetRGBPattern() returns tvERROR_NONE]
+    D -->|Failure| D1[Test case fail]
+    E -->|Success| F[Check RGB values match]
+    E -->|Failure| E1[Test case fail]
+    F -->|Success| G[TvTerm()]
+    F -->|Failure| F1[Test case fail]
+    G -->|Success| H[Test case pass]
+    G -->|Failure| G1[Test case fail]
+```
+
+
+### Test 47
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_SetAndGetGrayPattern`|
+|Description|Set and Gets the Gray Pattern within the range ( 0 - 255 ). The retrieved value should match the set value. Get values are retrieved from the database.|
+|Test Group|Module : 02|
+|Test Case ID|47|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Set the Gamma Pattern Mode to true using SetGammaPatternMode() | Mode = true | tvERROR_NONE | Should be successful |
+| 03 | Set the Gray Pattern using SetGrayPattern() | YUVValue = 100 | tvERROR_NONE | Should be successful |
+| 04 | Get the Gray Pattern using GetGrayPattern() | get_YUVValue = valid buffer | tvERROR_NONE, YUVValue = 100 | Should be successful |
+| 05 | If the status is not tvERROR_NONE or the set and get YUVValues do not match, terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit] -->|tvERROR_NONE| B[SetGammaPatternMode]
+    A -->|Failure| A1[Test case fail]
+    B -->|tvERROR_NONE| C[SetGrayPattern]
+    B -->|Failure| B1[Test case fail]
+    C -->|tvERROR_NONE| D[GetGrayPattern]
+    C -->|Failure| C1[Test case fail]
+    D -->|tvERROR_NONE, YUVValue matches| E[TvTerm]
+    D -->|Failure| D1[Test case fail]
+    E -->|tvERROR_NONE| F[Test case success]
+    E -->|Failure| E1[Test case fail]
+```
+
+
+### Test 48
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_RetrieveOpenCircuitStatus`|
+|Description|Verifies the functionality of retrieving the current open circuit status of the backlight hardware. It ensures that the returned status indicates whether any `LED` fault is detected.|
+|Test Group|Module : 02|
+|Test Case ID|48|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize the TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Retrieve the open circuit status using GetOpenCircuitStatus() | status = valid pointer | tvERROR_NONE | Should be successful |
+| 03 | Check if the status indicates an LED fault | status >= 1 | LED fault detected | Should be successful |
+| 04 | Check if the status indicates no LED fault | status = 0 | No LED fault detected | Should be successful |
+| 05 | Check if the status value is invalid | status < 0 | Invalid status value | Should fail |
+| 06 | Terminate the TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit()] -->|tvERROR_NONE| B[GetOpenCircuitStatus()]
+    A -->|!=tvERROR_NONE| A1[Test case fail]
+    B -->|tvERROR_NONE| C[Check returned status]
+    B -->|!=tvERROR_NONE| B1[Test case fail]
+    C -->|Status >= 1 or Status == 0| D[TvTerm()]
+    C -->|Status < 0 or Status > 1| C1[Test case fail]
+    D -->|tvERROR_NONE| E[Test case pass]
+    D -->|!=tvERROR_NONE| D1[Test case fail]
+```
+
+
+### Test 49
+
+|Title|Details|
+|--|--|
+|Function Name|`test_l2_tvSettings_EnableAndGetDynamicContrast`|
+|Description|Enable Dynamic Contrast - Verifies the functionality of enabling or disabling the dynamic contrast module. Check the status by get dynamic contrast.|
+|Test Group|Module : 02|
+|Test Case ID|49|
+|Priority|High|
+
+**Pre-Conditions :**
+None
+
+**Dependencies :**
+None
+
+**User Interaction :**
+If user chose to run the test in interactive mode, then the test case has to be selected via console.
+
+#### Test Procedure :
+
+| Variation / Steps | Description | Test Data | Expected Result | Notes|
+| -- | --------- | ---------- | -------------- | ----- |
+| 01 | Initialize TV using TvInit() | None | tvERROR_NONE | Should be successful |
+| 02 | Enable Dynamic Contrast using EnableDynamicContrast() | Enable = true | tvERROR_NONE | Should be successful |
+| 03 | Get Dynamic Contrast status using GetDynamicContrast() | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, "enabled" | Should be successful |
+| 04 | Disable Dynamic Contrast using EnableDynamicContrast() | Enable = false | tvERROR_NONE | Should be successful |
+| 05 | Get Dynamic Contrast status using GetDynamicContrast() | isDynamicContrastEnabled = valid buffer | tvERROR_NONE, "disabled" | Should be successful |
+| 06 | Terminate TV using TvTerm() | None | tvERROR_NONE | Should be successful |
+
+
+```mermaid
+graph TB
+    A[TvInit()] -->|tvERROR_NONE| B[EnableDynamicContrast(true)]
+    A -->|!=tvERROR_NONE| A1[Test case fail]
+    B -->|tvERROR_NONE| C[GetDynamicContrast()]
+    B -->|!=tvERROR_NONE| B1[Test case fail]
+    C -->|tvERROR_NONE and output=="enabled"| D[EnableDynamicContrast(false)]
+    C -->|!=tvERROR_NONE or output!="enabled"| C1[Test case fail]
+    D -->|tvERROR_NONE| E[GetDynamicContrast()]
+    D -->|!=tvERROR_NONE| D1[Test case fail]
+    E -->|tvERROR_NONE and output=="disabled"| F[TvTerm()]
+    E -->|!=tvERROR_NONE or output!="disabled"| E1[Test case fail]
+    F -->|tvERROR_NONE| G[Test case success]
+    F -->|!=tvERROR_NONE| F1[Test case fail]
+```
+
+

--- a/src/main.c
+++ b/src/main.c
@@ -1,98 +1,42 @@
-/**
-*  If not stated otherwise in this file or this component's LICENSE
-*  file the following copyright and licenses apply:
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:*
+* Copyright 2024 RDK Management
 *
-*  Copyright 2023 RDK Management
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-*  Licensed under the Apache License, Version 2.0 (the License);
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
 *
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an AS IS BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
-*/
-
-/**
- * @addtogroup HPK Hardware Porting Kit
- * @{
- * @par The Hardware Porting Kit
- * HPK is the next evolution of the well-defined Hardware Abstraction Layer
- * (HAL), but augmented with more comprehensive documentation and test suites
- * that OEM or SOC vendors can use to self-certify their ports before taking
- * them to RDKM for validation or to an operator for final integration and
- * deployment. The Hardware Porting Kit effectively enables an OEM and/or SOC
- * vendor to self-certify their own Video Accelerator devices, with minimal RDKM
- * assistance.
- *
- */
-
-/**
- * @addtogroup TV_Settings TV Settings Module
- * @{
- */
-
-/**
- * @addtogroup TV_Settings_HALTEST TV Settings HAL Tests
- * @{
- */
-
-/**
- * @defgroup TV_Settings_HALTEST_MAIN TV Settings HAL Tests Main File
- *  @{
- * @parblock
- *
- * ### Tests for TV_Settings HAL :
- *
- * This is to ensure that the API meets the operational requirements of the module across all vendors.
- *
- * **Pre-Conditions:** None @n
- * **Dependencies:** None @n
- *
- * Refer to Device Settings HAL Documentation Guide : [tv-settings_halSpec.md](../../docs/pages/tv-settings_halSpec.md)
- *
- * @endparblock
- */
-
-
-/**
-* @file main.c
-*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 */
 
 #include <ut.h>
-#include "test_config_read.h"
 
-extern int UT_register_APIDEF_l1_tests( void );
+extern int register_hal_l2_tests( void );
 
-int main(int argc, char** argv) 
+int main(int argc, char** argv)
 {
-	int registerReturn = 0;
-
-	/* Register tests as required, then call the UT-main to support switches and triggering */
-	UT_init( argc, argv );
-
-	config_read(argv[1]);
-	/* Check if tests are registered successfully */
-
-	registerReturn = UT_register_APIDEF_l1_tests();
-	if ( registerReturn == -1 )
-	{
-		printf("\n UT_register_APIDEF_l1_tests() returned failure");
-		return -1;
-	}
-
-	/* Begin test executions */
-	UT_run_tests();
-
-	return 0;
-
+    int registerReturn = 0;
+    /* Register tests as required, then call the UT-main to support switches and triggering */
+    UT_init( argc, argv );
+    /* Check if tests are registered successfully */
+    registerReturn = register_hal_l2_tests();
+    if (registerReturn == 0)
+    {
+        printf("register_hal_l2_tests() returned success");
+    }
+    else
+    {
+        printf("register_hal_l2_tests() returned failure");
+        return 1;
+    }
+    /* Begin test executions */
+    UT_run_tests();
+    return 0;
 }
-/** @} */ // End of TV_Settings_HALTEST_MAIN
-/** @} */ // End of TV_Settings_HALTEST
-/** @} */ // End of TV_Settings
-/** @} */ // End of HPK

--- a/src/test_l2_tvSettings.c
+++ b/src/test_l2_tvSettings.c
@@ -1,113 +1,3051 @@
-/**
-*  If not stated otherwise in this file or this component's LICENSE
-*  file the following copyright and licenses apply:
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:*
+* Copyright 2024 RDK Management
 *
-*  Copyright 2023 RDK Management
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-*  Licensed under the Apache License, Version 2.0 (the License);
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
 *
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an AS IS BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 */
-
-/**
- * @addtogroup HPK Hardware Porting Kit
- * @{
- * @par The Hardware Porting Kit
- * HPK is the next evolution of the well-defined Hardware Abstraction Layer
- * (HAL), but augmented with more comprehensive documentation and test suites
- * that OEM or SOC vendors can use to self-certify their ports before taking
- * them to RDKM for validation or to an operator for final integration and
- * deployment. The Hardware Porting Kit effectively enables an OEM and/or SOC
- * vendor to self-certify their own Video Accelerator devices, with minimal RDKM
- * assistance.
- *
- */
-
-/**
- * @addtogroup TV_Settings TV Settings Module
- * @{
- */
-
-/**
- * @addtogroup TV_Settings_HALTEST TV Settings HAL Tests
- * @{
- */
-
-/**
- * @defgroup TV_Settings_HALTEST_L2 TV Settings HAL Tests L2 File
- *  @{
- * @parblock
- *
- * ### L2 Tests for TV_Settings HAL :
- *
- * This is to ensure that the API meets the operational requirements of the module across all vendors.
- *
- * **Pre-Conditions:** None @n
- * **Dependencies:** None @n
- *
- * Refer to Device Settings HAL Documentation Guide : [tv-settings_halSpec.md](../../docs/pages/tv-settings_halSpec.md)
- *
- * @endparblock
- */
-
 
 /**
 * @file test_l2_tvSettings.c
+* @page tvSettings Level 2 Tests
 *
+* ## Module's Role
+* This module includes Level 2 functional tests (success and failure scenarios).
+* This is to ensure that the tvSettings APIs meet the requirements across all vendors.
+*
+* **Pre-Conditions:**  None@n
+* **Dependencies:** None@n
+*
+* Ref to API Definition specification documentation : [tvSettings_halSpec.md](../../docs/pages/tvSettings_halSpec.md)
 */
-
-#include <string.h>
-#include <stdlib.h>
 
 #include <ut.h>
 #include <ut_log.h>
+#include <ut_kvp_profile.h>
+#include <stdlib.h>
+#include "tvSettings.h"
+
+static int gTestGroup = 2;
+static int gTestID = 1;
 
 /**
-* @brief TODO: Describe the object of the test
+* @brief This test checks the functionality of the GetSupportedVideoFormats API in the tvSettings module
 *
-* TODO: Add the description of what is tested and why in this test
+* This test initializes the TV, retrieves the supported video formats, and checks if the number and types of formats returned are as expected. It then terminates the TV. The test is designed to verify that the GetSupportedVideoFormats API is working as expected and returning the correct video formats.
 *
-* **Test Group ID:** TODO: Add the group this test belongs to - Basic (for L1): 01 / Module (L2): 02 / Stress (L2): 03)@n
-* **Test Case ID:** TODO: Add the ID of the test case so that it can be logically tracked in the logs@n
+* **Test Group ID:** 02@n
+* **Test Case ID:** 001@n
 *
 * **Test Procedure:**
-* Refer to UT specification documentation [l2_module_test_specification.md](l2_module_test_specification.md)
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
 */
-void test_l2_tvSettings (void)
+
+void test_l2_tvSettings_GetSupportedVideoFormats(void)
 {
-	UT_FAIL("This function needs to be implemented!"); 
+    gTestID = 1;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    tvVideoFormatType_t *videoFormats[VIDEO_FORMAT_MAX] = {0};
+    unsigned short numberOfFormats;
+    ut_kvp_instance_t *pInstance = NULL;
+    uint32_t format;
+    char buffer[50];
+    int flag;
+    int j;
+
+    UT_LOG_DEBUG("Invoking TvInit with valid parameters");
+    status = TvInit();
+    UT_LOG_DEBUG("TvInit returned : %d",status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetTVSupportedVideoFormats with valid parameters");
+    status = GetTVSupportedVideoFormats(videoFormats, &numberOfFormats);
+    UT_LOG_DEBUG("GetTVSupportedVideoFormats returned : %d numberOfFormats :%d ",status, numberOfFormats );
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("GetTVSupportedVideoFormats failed with status: %d", status);
+        TvTerm();
+        return;
+    }
+
+    UT_ASSERT_TRUE(numberOfFormats >= 1 && numberOfFormats <= VIDEO_FORMAT_MAX);
+
+    UT_ASSERT_KVP_EQUAL_PROFILE_UINT16(numberOfFormats, "VideoFormat/numberOfFormats");
+
+    pInstance = ut_kvp_profile_getInstance();
+    for (int i=0;i<numberOfFormats;i++)
+    {
+        flag = 0;
+        sprintf(buffer, "VideoFormat/index/%d", i);
+        format = ut_kvp_getUInt32Field( pInstance, buffer);
+        j = 0;
+        for ( j=0; j< numberOfFormats; j++)
+        {
+            if (*videoFormats[j] == format)
+            {
+                flag = 1;
+                break;
+            }
+        }
+        if (flag == 1)
+        {
+            UT_PASS("VideoFormat match");
+            UT_LOG_DEBUG("Video Format : %d is in the list of supported VideoFormats", *videoFormats[j]);
+        }
+        else
+        {
+            UT_FAIL("VideoFormat mismatch");
+            UT_LOG_DEBUG("Video Format : %d is not in the list of supported VideoFormats ", *videoFormats[j]);
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_LOG_DEBUG("TvTerm returned : %d",status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test for GetCurrentVideoFormat API when there is no video playback
+*
+* This function tests the GetCurrentVideoFormat API when there is no video playback. It first initializes the TV settings using the TvInit API, then calls the GetCurrentVideoFormat API with a valid pointer to a tvVideoFormatType_t variable, and checks that the returned video format is VIDEO_FORMAT_SDR. Finally, it de-initializes the TV settings using the TvTerm API. The function uses the Cunit assertion macros to check that the return values of the APIs are as expected.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 002@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_GetCurrentVideoFormat_NoVideoPlayback(void)
+{
+    gTestID = 2;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    tvVideoFormatType_t videoFormat;
+
+    UT_LOG_DEBUG("Invoking TvInit with no input parameters");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetCurrentVideoFormat with valid pointer to tvVideoFormatType_t variable");
+    status = GetCurrentVideoFormat(&videoFormat);
+    UT_LOG_DEBUG("Return status: %d, Video Format: %d", status, videoFormat);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(videoFormat, VIDEO_FORMAT_SDR);
+    if (status != tvERROR_NONE || videoFormat != VIDEO_FORMAT_SDR)
+    {
+        UT_LOG_ERROR("GetCurrentVideoFormat failed with status: %d", status);
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm with no input parameters");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the current video resolution
+*
+* This function tests the GetCurrentVideoResolution API by first initializing the TV settings using TvInit, then calling GetCurrentVideoResolution and checking the returned values, and finally de-initializing the TV settings using TvTerm. If GetCurrentVideoResolution fails, TvTerm is called to clean up. The function uses Cunit's assertion functions to check the return values of the APIs and the values in the returned tvResolutionParam_t structure.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 003@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_VerifyCurrentVideoResolution(void)
+{
+    gTestID = 3;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    tvResolutionParam_t res;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_LOG_DEBUG("TvInit status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetCurrentVideoResolution with valid buffer");
+    status = GetCurrentVideoResolution(&res);
+    UT_LOG_DEBUG("GetCurrentVideoResolution status: %d, resolutionValue: %d, frameHeight: %d, frameWidth: %d, isInterlaced: %d", status, res.resolutionValue, res.frameHeight, res.frameWidth, res.isInterlaced);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm due to failure in GetCurrentVideoResolution");
+        TvTerm();
+        return;
+    }
+    UT_ASSERT_EQUAL(res.resolutionValue, tvVideoResolution_NONE);
+    UT_ASSERT_EQUAL(res.frameHeight, 0);
+    UT_ASSERT_EQUAL(res.frameWidth, 0);
+    UT_ASSERT_EQUAL(res.isInterlaced, 0);
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_LOG_DEBUG("TvTerm status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the frame rate when the TV is stopped
+*
+* This function tests the behavior of the GetCurrentVideoFrameRate API when the TV is stopped. It first initializes the TV settings using TvInit, then gets the current video frame rate, and finally de-initializes the TV settings using TvTerm. The function uses assertions to verify that the APIs return the expected results. If GetCurrentVideoFrameRate fails, it logs an error and calls TvTerm to clean up.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 004@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_VerifyFrameRateWhenStopped(void)
+{
+    gTestID = 4;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t error;
+    tvVideoFrameRate_t frameRate;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    error = TvInit();
+    UT_LOG_DEBUG("Return status: %d", error);
+    UT_ASSERT_EQUAL_FATAL(error, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetCurrentVideoFrameRate");
+    error = GetCurrentVideoFrameRate(&frameRate);
+    UT_LOG_DEBUG("Frame rate: %d, Return status: %d", frameRate, error);
+    UT_ASSERT_EQUAL(error, tvERROR_NONE);
+    UT_ASSERT_EQUAL(frameRate, tvVideoFrameRate_NONE);
+    if (error != tvERROR_NONE || frameRate != tvVideoFrameRate_NONE)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm due to failure of GetCurrentVideoFrameRate");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    error = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", error);
+    UT_ASSERT_EQUAL_FATAL(error, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test for getting supported video sources from TV settings
+*
+* This test verifies if the GetTVSupportedVideoSources function is able to retrieve the supported video sources correctly. It checks if the function returns the correct status and the number of sources is within the expected range. Each source is then validated against the profile.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 005@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_GetTVSupportedVideoSources(void)
+{
+    gTestID = 5;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    tvVideoSrcType_t *videoSources[VIDEO_SOURCE_MAX];
+    unsigned short numberOfSources;
+    ut_kvp_instance_t *pInstance = NULL;
+    char buffer[50];
+    uint32_t source;
+    int flag;
+    int j;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetTVSupportedVideoSources()");
+    status = GetTVSupportedVideoSources(videoSources, &numberOfSources);
+    UT_LOG_DEBUG("Return status: %d, Number of sources: %d", status, numberOfSources);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm due to failure in GetTVSupportedVideoSources");
+        TvTerm();
+        return;
+    }
+
+    UT_ASSERT_TRUE(numberOfSources >= 1 && numberOfSources <= VIDEO_SOURCE_MAX);
+
+    UT_ASSERT_KVP_EQUAL_PROFILE_UINT16(numberOfSources, "VideoSource/numberOfSources");
+
+    pInstance = ut_kvp_profile_getInstance();
+    for (int i=0;i<numberOfSources;i++)
+    {
+        flag = 0;
+        sprintf(buffer, "VideoSource/index/%d", i);
+        source = ut_kvp_getUInt32Field( pInstance, buffer);
+        j = 0;
+        for ( j=0; j< numberOfSources; j++)
+        {
+            if (*videoSources[j] == source)
+            {
+                flag = 1;
+                break;
+            }
+        }
+        if (flag == 1)
+        {
+            UT_PASS("VideoSource match");
+            UT_LOG_DEBUG("Video source : %d is in the list of supported VideoSources", *videoSources[j]);
+        }
+        else
+        {
+            UT_FAIL("VideoSource mismatch");
+            UT_LOG_DEBUG("Video Source : %d is not in the list of supported VideoFormats ", *videoSources[j]);
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test verifies if there is no video source in the TV settings
+*
+* This test function is designed to check the absence of a video source in the TV settings. It does this by invoking the TvInit() function, checking the current video source, and then terminating the TV. The test is crucial to ensure that the TV settings are correctly initialized and terminated, and that the video source is correctly set.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 006@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_VerifyNoVideoSource(void)
+{
+    gTestID = 6;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int currentSource;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetCurrentVideoSource() with valid pointer");
+    status = GetCurrentVideoSource(&currentSource);
+    UT_LOG_DEBUG("Return status: %d, Current Source: %d", status, currentSource);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(currentSource, VIDEO_SOURCE_IP);
+    if (status != tvERROR_NONE || currentSource != VIDEO_SOURCE_IP)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm due to failure of GetCurrentVideoSource");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the SetBacklight and GetBacklight APIs
+*
+* This function tests the SetBacklight and GetBacklight APIs by setting a valid backlight value and then retrieving it to verify if the set value is correctly retrieved. The TvInit and TvTerm APIs are used as pre and post requisite APIs respectively.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 007@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetBacklight(void)
+{
+    gTestID = 7;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int backlight = 50;
+    int getBacklight;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetBacklight() with valid backlight value: %d", backlight);
+    status = SetBacklight(backlight);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetBacklight() failed with status: %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm() due to failure of SetBacklight()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetBacklight()");
+    status = GetBacklight(&getBacklight);
+    UT_LOG_DEBUG("Return status: %d, Current backlight value: %d", status, getBacklight);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(backlight, getBacklight);
+
+    if (status != tvERROR_NONE || backlight != getBacklight)
+    {
+        UT_LOG_ERROR("GetBacklight() failed with status: %d", status);
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to verify the functionality of setting and getting the backlight fade in a TV settings module.
+*
+* In this test, the SetBacklightFade() function is invoked with specific parameters and then the GetCurrentBacklightFade() function is called to verify if the previously set parameters are correctly retrieved. The test ensures that the TV settings module correctly handles the backlight fade settings and can retrieve them accurately.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 008@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetBacklightFade(void)
+{
+    gTestID = 8;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int from = 50;
+    int to = 70;
+    int duration = 5000;
+    int get_from, get_to, get_current;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetBacklightFade() with from: %d, to: %d, duration: %d", from, to, duration);
+    status = SetBacklightFade(from, to, duration);
+    UT_LOG_DEBUG("SetBacklightFade() returned status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm() due to failure in SetBacklightFade()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetCurrentBacklightFade()");
+    status = GetCurrentBacklightFade(&get_from, &get_to, &get_current);
+    UT_LOG_DEBUG("GetCurrentBacklightFade() returned from: %d, to: %d, current: %d, status: %d", get_from, get_to, get_current, status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(from, get_from);
+    UT_ASSERT_EQUAL(to, get_to);
+    UT_ASSERT_EQUAL(duration, get_current);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm() due to failure in GetCurrentBacklightFade()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("TvTerm() returned status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the function GetSupportedBacklightModes
+*
+* This test case verifies if the function GetSupportedBacklightModes is able to fetch the supported backlight modes correctly. The function is tested under normal conditions with valid input parameters.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 009@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_GetSupportedBacklightModes(void)
+{
+    gTestID = 9;
+    tvError_t status;
+    int blModes;
+    int getblModes;
+    int count = 0;
+    char buffer[50];
+    ut_kvp_instance_t *pInstance = NULL;
+    int flag = 0;
+
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_LOG_DEBUG("TvInit status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetSupportedBacklightModes with valid pointer");
+    status = GetSupportedBacklightModes(&getblModes);
+    UT_LOG_DEBUG("GetSupportedBacklightModes status: %d, blModes: %d", status, getblModes);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm() due to failure in GetSupportedBacklightModes()");
+        TvTerm();
+        return;
+    }
+
+    pInstance = ut_kvp_profile_getInstance();
+    count = ut_kvp_getListCount(pInstance,"BacklightControl/index");
+    for (int i=0;i<count;i++)
+    {
+        flag = 0;
+        sprintf(buffer, "BacklightControl/index/%d", i);
+        blModes = ut_kvp_getUInt32Field( pInstance, buffer);
+
+        if (getblModes == blModes)
+        {
+                flag = 1;
+                break;
+        }
+    }
+    if (flag == 1)
+    {
+        UT_PASS("BacklightControl match");
+        UT_LOG_DEBUG("BacklightControl : %d is in the list of supported BacklightControl modes", getblModes);
+    }
+    else
+    {
+        UT_FAIL("BacklightControl mismatch");
+        UT_LOG_DEBUG("BacklightControl : %d is not in the list of supported BacklightControl modes ", getblModes);
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_LOG_DEBUG("TvTerm status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test checks if the Set and Get functions for Backlight Mode in TV settings are working as expected
+*
+* In this test, the Backlight Mode is set using the SetCurrentBacklightMode() function and then retrieved using the GetCurrentBacklightMode() function. The test checks if the mode retrieved matches the mode set, thereby testing the correctness of both the Set and Get functions.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 010@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetBacklightMode(void)
+{
+    gTestID = 10;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t ret;
+    tvBacklightMode_t setMode = tvBacklightMode_MANUAL;
+    tvBacklightMode_t getMode;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    ret = TvInit();
+    UT_LOG_DEBUG("TvInit() returned %d", ret);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetCurrentBacklightMode() with valid backlight mode %d",setMode);
+    ret = SetCurrentBacklightMode(setMode);
+    UT_LOG_DEBUG("SetCurrentBacklightMode() returned %d", ret);
+    UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+    if (ret != tvERROR_NONE)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm() due to failure in SetCurrentBacklightMode()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetCurrentBacklightMode()");
+    ret = GetCurrentBacklightMode(&getMode);
+    UT_LOG_DEBUG("GetCurrentBacklightMode() returned %d and mode %d", ret, getMode);
+    UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+    if (ret != tvERROR_NONE)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm() due to failure in GetCurrentBacklightMode()");
+        TvTerm();
+        return;
+    }
+    UT_ASSERT_EQUAL(getMode, setMode);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    ret = TvTerm();
+    UT_LOG_DEBUG("TvTerm() returned %d", ret);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the function GetSupportedDimmingModes in tvSettings module
+*
+* This test case verifies if the function GetSupportedDimmingModes correctly retrieves the supported dimming modes from the TV settings. The test first initializes the TV settings using TvInit function, then calls GetSupportedDimmingModes to get the supported dimming modes, and finally terminates the TV settings using TvTerm function. The test asserts if the returned status of these functions is tvERROR_NONE, indicating successful execution. The test also checks if the number of dimming modes returned by GetSupportedDimmingModes matches with the value in the platform-supported configurations file 'Sink-4K-TvSettings.yaml'.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 011@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_GetSupportedDimmingModes(void)
+{
+    gTestID = 11;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    tvDimmingMode_t *dimmingModes[tvDimmingMode_MAX];
+    unsigned short numDimmingModes;
+    ut_kvp_instance_t *pInstance = NULL;
+    char buffer[50];
+    uint32_t mode;
+    int flag;
+    int j;
+
+    UT_LOG_DEBUG("Invoking TvInit with no input parameters");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetTVSupportedDimmingModes with valid output parameters");
+    status = GetTVSupportedDimmingModes(dimmingModes, &numDimmingModes);
+    UT_LOG_DEBUG("Return status: %d, Number of Dimming Modes: %d", status, numDimmingModes);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("GetTVSupportedDimmingModes failed with status: %d", status);
+        TvTerm();
+        return;
+    }
+
+    UT_ASSERT_TRUE(numDimmingModes >= 1 && numDimmingModes <= VIDEO_SOURCE_MAX);
+
+    UT_ASSERT_KVP_EQUAL_PROFILE_UINT16(numDimmingModes, "DimmingMode/numberOfDimmingModes");
+
+    pInstance = ut_kvp_profile_getInstance();
+    for (int i=0;i<numDimmingModes;i++)
+    {
+        flag = 0;
+        sprintf(buffer, "DimmingMode/index/%d", i);
+        mode = ut_kvp_getUInt32Field( pInstance, buffer);
+        j = 0;
+        for ( j=0; j< numDimmingModes; j++)
+        {
+            if (*dimmingModes[j] == mode)
+            {
+                flag = 1;
+                break;
+            }
+        }
+        if (flag == 1)
+        {
+            UT_PASS("dimmingMode match");
+            UT_LOG_DEBUG("dimmingMode: %d is in the list of supported dimmingModes", *dimmingModes[j]);
+        }
+        else
+        {
+            UT_FAIL("dimmingMode mismatch");
+            UT_LOG_DEBUG("dimmingModes : %d is not in the list of supported dimmingModes ", *dimmingModes[j]);
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm with no input parameters");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the setting and getting of TV Dimming Mode
+*
+* This test case verifies the functionality of setting and getting the TV Dimming Mode. It checks if the TV Dimming Mode can be set correctly and if the same can be retrieved without any errors. The test is performed for three different dimming modes - local, fixed, and global.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 012@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetDimmingMode(void)
+{
+    gTestID = 12;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    const char *dimmingModes[] = {"local", "fixed", "global"};
+    char getDimmingMode[10];
+
+    status = TvInit();
+    UT_LOG_DEBUG("Invoking TvInit");
+    UT_LOG_DEBUG("TvInit status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for(int i = 0; i < 3; i++)
+    {
+        UT_LOG_DEBUG("Invoking SetTVDimmingMode with %s", dimmingModes[i]);
+        status = SetTVDimmingMode(dimmingModes[i]);
+        UT_LOG_DEBUG("SetTVDimmingMode status: %d", status);
+        UT_ASSERT_EQUAL(status, tvERROR_NONE);
+        if(status != tvERROR_NONE)
+        {
+            UT_LOG_ERROR("SetTVDimmingMode failed with status: %d", status);
+            continue;
+        }
+
+        UT_LOG_DEBUG("Invoking GetTVDimmingMode");
+        status = GetTVDimmingMode(getDimmingMode);
+        UT_LOG_DEBUG("GetTVDimmingMode status: %d, dimmingMode: %s", status, getDimmingMode);
+        UT_ASSERT_EQUAL(status, tvERROR_NONE);
+        if(status != tvERROR_NONE)
+        {
+            UT_LOG_ERROR("GetTVDimmingMode failed with status: %d", status);
+        }
+
+        UT_ASSERT_STRING_EQUAL(getDimmingMode, dimmingModes[i]);
+    }
+
+    status = TvTerm();
+    UT_LOG_DEBUG("Invoking TvTerm");
+    UT_LOG_DEBUG("TvTerm status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the functionality of Set and Get Local Dimming Level
+*
+* This test case verifies if the SetLocalDimmingLevel and GetLocalDimmingLevel functions are working as expected. It sets the local dimming level and then gets the level to check if the set value is correctly retrieved. This is done for all possible dimming levels.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 013@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetLocalDimmingLevel(void)
+{
+    gTestID = 13;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    ldimStateLevel_t ldimStateLevel, ldimStateLevelGet;
+    ldimStateLevel_t ldimStateLevels[] = {LDIM_STATE_NONBOOST, LDIM_STATE_BOOST, LDIM_STATE_BURST};
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("TvInit() returned %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for (int i = 0; i < 3; i++)
+    {
+        ldimStateLevel = ldimStateLevels[i];
+
+        UT_LOG_DEBUG("Invoking SetLocalDimmingLevel() with %d", ldimStateLevel);
+        status = SetLocalDimmingLevel(ldimStateLevel);
+        UT_LOG_DEBUG("SetLocalDimmingLevel() returned %d", status);
+        UT_ASSERT_EQUAL(status, tvERROR_NONE);
+        if (status != tvERROR_NONE)
+        {
+            UT_LOG_DEBUG("SetLocalDimmingLevel() failed with status : %d", status);
+            continue;
+        }
+
+        UT_LOG_DEBUG("Invoking GetLocalDimmingLevel()");
+        status = GetLocalDimmingLevel(&ldimStateLevelGet);
+        UT_LOG_DEBUG("GetLocalDimmingLevel() returned %d and level %d", status, ldimStateLevelGet);
+        UT_ASSERT_EQUAL(status, tvERROR_NONE);
+        if(status != tvERROR_NONE)
+        {
+            UT_LOG_ERROR("GetLocalDimmingLevel failed with status: %d", status);
+        }
+        UT_ASSERT_EQUAL(ldimStateLevel, ldimStateLevelGet);
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("TvTerm() returned %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the Set and Get Brightness functionality of the TV settings
+*
+* This test initializes the TV settings, sets the brightness to a specific value, retrieves the set brightness, and then de-initializes the TV settings. It uses CUnit assertions to verify the return values of the API calls. The purpose of this test is to ensure that the SetBrightness and GetBrightness functions of the TV settings are working as expected.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 014@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetBrightness(void)
+{
+    gTestID = 14;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int brightness = 50;
+    int get_brightness;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_LOG_DEBUG("TvInit status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetBrightness with brightness: %d", brightness);
+    status = SetBrightness(brightness);
+    UT_LOG_DEBUG("SetBrightness status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetBrightness failed with status: %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm due to SetBrightness failure");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetBrightness");
+    status = GetBrightness(&get_brightness);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_LOG_DEBUG("GetBrightness status: %d, brightness: %d", status, get_brightness);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE || get_brightness != brightness)
+    {
+        UT_LOG_ERROR("GetBrightness failed with status: %d", status);
+    }
+    UT_ASSERT_EQUAL(brightness, get_brightness);
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_LOG_DEBUG("TvTerm status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the functionality of Set and Get Contrast in TV settings
+*
+* This test case validates the SetContrast and GetContrast functions of the TV settings API.
+* The test sets a contrast value and then retrieves it to verify if the set value and retrieved value are same.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 015@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetContrast(void)
+{
+    gTestID = 15;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t ret;
+    int contrast = 50;
+    int getContrast;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    ret = TvInit();
+    UT_LOG_DEBUG("Return status: %d", ret);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetContrast() with valid contrast value: %d", contrast);
+    ret = SetContrast(contrast);
+    UT_LOG_DEBUG("Return status: %d", ret);
+    UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+    if (ret != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetContrast failed with status: %d", ret);
+        UT_LOG_DEBUG("Invoking TvTerm due to SetContrast failure");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetContrast()");
+    ret = GetContrast(&getContrast);
+    UT_LOG_DEBUG("Return status: %d, Contrast value: %d", ret, getContrast);
+    UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+
+    if (ret != tvERROR_NONE || getContrast != contrast)
+    {
+        UT_LOG_ERROR("Mismatch in set and get contrast values. Set: %d, Get: %d", contrast, getContrast);
+    }
+    UT_ASSERT_EQUAL(contrast, getContrast);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    ret = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", ret);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test for setting and getting the sharpness of the TV
+*
+* This test checks if the SetSharpness and GetSharpness functions of the TV settings API work as expected. The sharpness is set to a specific value and then retrieved to verify if the set value is correctly stored and retrieved.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 016@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetSharpness(void)
+{
+    gTestID = 16;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int setSharpness = 50;
+    int getSharpness = 0;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetSharpness() with sharpness: %d", setSharpness);
+    status = SetSharpness(setSharpness);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetSharpness() failed with status: %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetSharpness()");
+    status = GetSharpness(&getSharpness);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_LOG_DEBUG("Return status: %d, Sharpness: %d", status, getSharpness);
+    if (status != tvERROR_NONE || setSharpness != getSharpness)
+    {
+        UT_LOG_ERROR("GetSharpness() failed with status: %d", status);
+    }
+
+    UT_ASSERT_EQUAL(setSharpness, getSharpness);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to verify the Set and Get functionality of the Saturation parameter in the TV settings
+*
+* In this test, the SetSaturation function is invoked to set a specific saturation value. Subsequently, the GetSaturation function is called to retrieve the set value. The test verifies if the retrieved value matches the set value, thereby validating the Set and Get functionality of the Saturation parameter.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 017@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetSaturation(void)
+{
+    gTestID = 17;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t ret;
+    int saturation_set = 50;
+    int saturation_get;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    ret = TvInit();
+    UT_LOG_DEBUG("Return status: %d", ret);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetSaturation() with saturation value: %d", saturation_set);
+    ret = SetSaturation(saturation_set);
+    UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+    if (ret != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetSaturation failed with error: %d", ret);
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetSaturation()");
+    ret = GetSaturation(&saturation_get);
+    UT_LOG_DEBUG("Retrieved status : %d saturation value: %d", ret, saturation_get);
+    UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+
+    if (ret != tvERROR_NONE || saturation_set != saturation_get)
+    {
+        UT_LOG_ERROR("GetSaturation failed with error: %d", ret);
+    }
+    UT_ASSERT_EQUAL(saturation_set, saturation_get);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    ret = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", ret);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the Set and Get Hue functionality of the TV settings
+*
+* This test initializes the TV settings, sets a hue value, retrieves the hue value and verifies it matches the set value, and then de-initializes the TV settings. It uses CUnit assertions to verify the return values of the API calls and logs the progress of the test.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 018@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetHue(void)
+{
+    gTestID = 18;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int hue = 50;
+    int getHue;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetHue with hue: %d", hue);
+    status = SetHue(hue);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetHue failed with status: %d", status);
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetHue");
+    status = GetHue(&getHue);
+    UT_LOG_DEBUG("Return status: %d, Hue: %d", status, getHue);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE || hue != getHue)
+    {
+        UT_LOG_ERROR("GetHue failed with status: %d", status);
+    }
+    UT_ASSERT_EQUAL(hue, getHue);
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the Set and Get functionality of Color Temperature in TV settings
+*
+* This test case verifies if the SetColorTemperature and GetColorTemperature functions are working as expected.
+* The test first sets a color temperature value and then retrieves it to check if the set value is correctly stored and retrieved.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 019@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetColorTemperature(void)
+{
+    gTestID = 19;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    tvColorTemp_t colorTemp = tvColorTemp_STANDARD;
+    tvColorTemp_t getColorTemp;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetColorTemperature with colorTemp = %d", colorTemp);
+    status = SetColorTemperature(colorTemp);
+    UT_LOG_DEBUG("SetColorTemperature returned status = %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetColorTemperature failed with status = %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm due to failure of SetColorTemperature");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetColorTemperature");
+    status = GetColorTemperature(&getColorTemp);
+    UT_LOG_DEBUG("GetColorTemperature returned status = %d and colorTemp = %d", status, getColorTemp);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE || colorTemp != getColorTemp)
+    {
+        UT_LOG_ERROR("GetColorTemperature failed with status = %d", status);
+    }
+    UT_ASSERT_EQUAL(colorTemp, getColorTemp);
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to verify the functionality of setting and getting the aspect ratio in a TV settings module.
+*
+* In this test, the aspect ratio is first set to a specific mode (4x3) using the SetAspectRatio() function. The GetAspectRatio() function is then invoked to retrieve the current aspect ratio. The test verifies that the aspect ratio retrieved matches the one that was set, ensuring the correct functionality of both SetAspectRatio() and GetAspectRatio() functions.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 020@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetAspectRatio(void)
+{
+    gTestID = 20;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    tvDisplayMode_t setMode = tvDisplayMode_4x3;
+    tvDisplayMode_t getMode;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetAspectRatio() with tvDisplayMode_4x3");
+    status = SetAspectRatio(setMode);
+    UT_LOG_DEBUG("SetAspectRatio() returned status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetAspectRatio() failed with status: %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetAspectRatio()");
+    status = GetAspectRatio(&getMode);
+    UT_LOG_DEBUG("GetAspectRatio() returned mode: %d and status: %d", getMode, status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+    if (status != tvERROR_NONE || setMode != getMode)
+    {
+        UT_LOG_ERROR("GetAspectRatio() failed with status: %d", status);
+    }
+
+    UT_ASSERT_EQUAL(setMode, getMode);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test checks the functionality of SetAndGetLowLatencyState API
+*
+* This test aims to verify the correct functionality of SetAndGetLowLatencyState API. It first sets the low latency state and then gets the state to verify if the set operation was successful. The test is designed to ensure that the API is working as expected and is able to set and get the low latency state correctly.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 021@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetLowLatencyState(void)
+{
+    gTestID = 21;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int lowlatencystate;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetLowLatencyState(1)");
+    status = SetLowLatencyState(1);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetLowLatencyState(1) failed with status %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetLowLatencyState(&lowlatencystate)");
+    status = GetLowLatencyState(&lowlatencystate);
+    UT_LOG_DEBUG("GetLowLatencyState() returned lowlatencystate: %d and status: %d", lowlatencystate, status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE || lowlatencystate != 1)
+    {
+        UT_LOG_ERROR("GetLowLatencyState() failed with status %d, lowlatencystate %d", status, lowlatencystate);
+    }
+    UT_ASSERT_EQUAL(lowlatencystate, 1);
+
+    UT_LOG_DEBUG("Invoking SetLowLatencyState(0)");
+    status = SetLowLatencyState(0);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetLowLatencyState(0) failed with status %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetLowLatencyState(&lowlatencystate)");
+    status = GetLowLatencyState(&lowlatencystate);
+    UT_LOG_DEBUG("GetLowLatencyState() returned lowlatencystate: %d and status: %d", lowlatencystate, status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(lowlatencystate, 0);
+    if (status != tvERROR_NONE || lowlatencystate != 0)
+    {
+        UT_LOG_ERROR("GetLowLatencyState(&lowlatencystate) failed with status %d, lowlatencystate %d", status, lowlatencystate);
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test checks the functionality of setting and getting dynamic contrast in TV settings
+*
+* This test function tests the SetDynamicContrast and GetDynamicContrast functions of the TV settings API. It first sets the dynamic contrast to "enabled" and then gets the dynamic contrast to verify if it is set correctly. It then sets the dynamic contrast to "disabled" and again gets the dynamic contrast to verify if it is set correctly. The test ensures that the SetDynamicContrast and GetDynamicContrast functions are working as expected.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 022@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetDynamicContrast(void)
+{
+    gTestID = 22;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    char isDynamicContrastEnabled[10];
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetDynamicContrast with dynamicContrastEnable = enabled");
+    status = SetDynamicContrast("enabled");
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetDynamicContrast(enabled) failed with status %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetDynamicContrast");
+    status = GetDynamicContrast(isDynamicContrastEnabled);
+    UT_LOG_DEBUG("Return status: %d, isDynamicContrastEnabled: %s", status, isDynamicContrastEnabled);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE || strcmp(isDynamicContrastEnabled,"enabled"))
+    {
+        UT_LOG_ERROR("GetDynamicContrast() failed with status %d, DynamicContrast: %s", status, isDynamicContrastEnabled);
+    }
+    UT_ASSERT_STRING_EQUAL(isDynamicContrastEnabled, "enabled");
+
+    UT_LOG_DEBUG("Invoking SetDynamicContrast with dynamicContrastEnable = disabled");
+    status = SetDynamicContrast("disabled");
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_LOG_DEBUG("Return status: %d", status);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetDynamicContrast(disabled) failed with status %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetDynamicContrast");
+    status = GetDynamicContrast(isDynamicContrastEnabled);
+    UT_LOG_DEBUG("Return status: %d, isDynamicContrastEnabled: %s", status, isDynamicContrastEnabled);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE || strcmp(isDynamicContrastEnabled,"disabled"))
+    {
+        UT_LOG_ERROR("GetDynamicContrast() failed with status %d, DynamicContrast: %s", status, isDynamicContrastEnabled);
+    }
+    UT_ASSERT_STRING_EQUAL(isDynamicContrastEnabled, "disabled");
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to set and get the dynamic gamma value in TV settings
+*
+* This test function initializes the TV settings, sets a dynamic gamma value, retrieves the set value, and then terminates the TV settings. It uses assertions to validate the return values of the API calls and logs the progress of the test.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 023@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetDynamicGamma(void)
+{
+    gTestID = 23;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    double setGammaValue = 2.0;
+    double getGammaValue = 0.0;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("TvInit() returned status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetDynamicGamma() with valid gamma value: %f", setGammaValue);
+    status = SetDynamicGamma(setGammaValue);
+    UT_LOG_DEBUG("SetDynamicGamma() returned status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetDynamicGamma() failed with status: %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetDynamicGamma()");
+    status = GetDynamicGamma(&getGammaValue);
+    UT_LOG_DEBUG("GetDynamicGamma() returned gamma value: %f and status: %d", getGammaValue, status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE || setGammaValue != getGammaValue)
+    {
+        UT_LOG_ERROR("GetDynamicGamma() failed with status %d, GammaValue: %s", status, getGammaValue);
+    }
+    UT_ASSERT_EQUAL(setGammaValue, getGammaValue);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("TvTerm() returned status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test checks the GetSupportedDolbyVisionModes function of the L2 TV Settings API
+*
+* This test is designed to verify the functionality of the GetSupportedDolbyVisionModes function. It checks if the function correctly retrieves the supported Dolby Vision modes from the TV settings. The test first initializes the TV settings, then calls the GetSupportedDolbyVisionModes function with valid parameters, and finally terminates the TV settings. The test asserts that the function calls return no errors and that the count of the supported modes is within the valid range.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 024@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_GetSupportedDolbyVisionModes(void)
+{
+    gTestID = 24;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    tvDolbyMode_t *dvModes[tvMode_Max];
+    unsigned short count;
+    ut_kvp_instance_t *pInstance = NULL;
+    char buffer[50];
+    uint32_t mode;
+    int flag;
+    int j;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_LOG_DEBUG("TvInit status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetTVSupportedDolbyVisionModes with valid dvModes and count");
+    status = GetTVSupportedDolbyVisionModes(dvModes, &count);
+    UT_LOG_DEBUG("GetTVSupportedDolbyVisionModes status: %d, count: %d", status, count);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("GetTVSupportedDolbyVisionModes failed with status: %d", status);
+        TvTerm();
+        return;
+    }
+
+    UT_ASSERT_TRUE(count >= 0 && count <= tvMode_Max);
+
+    UT_ASSERT_KVP_EQUAL_PROFILE_UINT16(count, "DolbyVisionMode/numberOfDolbyVisionMode");
+
+    pInstance = ut_kvp_profile_getInstance();
+    for (int i=0;i<count;i++)
+    {
+        flag = 0;
+        sprintf(buffer, "DolbyVisionMode/index/%d", i);
+        mode = ut_kvp_getUInt32Field( pInstance, buffer);
+        j = 0;
+        for ( j=0; j< count; j++)
+        {
+            if (*dvModes[j] == mode)
+            {
+                flag = 1;
+                break;
+            }
+        }
+        if (flag == 1)
+        {
+            UT_PASS("DolbyVisionMode match");
+            UT_LOG_DEBUG("DolbyVision Mode : %d is in the list of supported DolbyVisionModes", *dvModes[j]);
+        }
+        else
+        {
+            UT_FAIL("DolbyVisionMode mismatch");
+            UT_LOG_DEBUG("DolbyVisionMode : %d is not in the list of supported DolbyVisionModes ", *dvModes[j]);
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_LOG_DEBUG("TvTerm status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the setting and getting of Dolby Vision Mode
+*
+* This test case verifies the functionality of setting and getting the Dolby Vision Mode in a TV. It ensures that the SetTVDolbyVisionMode and GetTVDolbyVisionMode functions work as expected and there is no mismatch in the set and get Dolby Vision Mode.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 025@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetDolbyVisionMode(void)
+{
+    gTestID = 25;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    tvDolbyMode_t dolbyMode = tvDolbyMode_Dark;
+    tvDolbyMode_t getDolbyMode;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetTVDolbyVisionMode with dolbyMode: %d", dolbyMode);
+    status = SetTVDolbyVisionMode(dolbyMode);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE)
+    {
+        UT_LOG_ERROR("SetTVDolbyVisionMode failed with status: %d", status);
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetTVDolbyVisionMode");
+    status = GetTVDolbyVisionMode(&getDolbyMode);
+    UT_LOG_DEBUG("Return status: %d, getDolbyMode: %d", status, getDolbyMode);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(getDolbyMode, dolbyMode);
+
+    if (status != tvERROR_NONE || getDolbyMode != dolbyMode)
+    {
+        UT_LOG_ERROR("Mismatch in set and get Dolby Vision Mode");
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the function GetTVSupportedPictureModes
+*
+* This test verifies if the function GetTVSupportedPictureModes correctly retrieves the supported picture modes. It checks if the function returns the correct status and the count of supported picture modes is within the expected range.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 026@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_GetTVSupportedPictureModes(void)
+{
+    gTestID = 26;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    pic_modes_t *pictureModes[PIC_MODES_SUPPORTED_MAX];
+    unsigned short count;
+
+    UT_LOG_DEBUG("Invoking TvInit with no input parameters");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetTVSupportedPictureModes with valid pictureModes and count buffers");
+    status = GetTVSupportedPictureModes(pictureModes, &count);
+    UT_LOG_DEBUG("Return status: %d, count: %d", status, count);
+    UT_ASSERT_NOT_EQUAL(status, tvERROR_INVALID_PARAM);
+    UT_ASSERT_NOT_EQUAL(status, tvERROR_INVALID_STATE);
+    UT_ASSERT_TRUE(count >= 1 && count <= PIC_MODES_SUPPORTED_MAX);
+
+    for (int i = 0; i < count; i++)
+    {
+        UT_ASSERT_KVP_EQUAL_PROFILE_STRING(pictureModes[i]->name, "PictureMode/index");
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm with no input parameters");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to validate the Set and Get Picture Mode functionality of the TV settings
+*
+* In this test, the TV is initialized and the supported picture modes are fetched. Each of these modes is then set as the current picture mode and retrieved to verify if the setting was successful. The TV is terminated at the end of the test. This test is crucial to ensure that the user can successfully change and retrieve the picture mode settings of the TV.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 027@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetPictureMode(void)
+{
+    gTestID = 27;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    pic_modes_t *pictureModes[PIC_MODES_SUPPORTED_MAX];
+    unsigned short count;
+    char pictureMode[PIC_MODE_NAME_MAX];
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+    UT_LOG_DEBUG("TvInit status: %d", status);
+
+    UT_LOG_DEBUG("Invoking GetTVSupportedPictureModes()");
+    status = GetTVSupportedPictureModes(pictureModes, &count);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_LOG_DEBUG("GetTVSupportedPictureModes status: %d, count: %d", status, count);
+    UT_ASSERT_TRUE(count >= 1 && count <= PIC_MODES_SUPPORTED_MAX);
+
+    for (int i = 0; i < count; i++) {
+        UT_LOG_DEBUG("Invoking SetTVPictureMode() with pictureMode: %s", pictureModes[i]->name);
+        status = SetTVPictureMode(pictureModes[i]->name);
+        UT_ASSERT_EQUAL(status, tvERROR_NONE);
+        UT_LOG_DEBUG("SetTVPictureMode status: %d", status);
+
+        UT_LOG_DEBUG("Invoking GetTVPictureMode()");
+        status = GetTVPictureMode(pictureMode);
+        UT_ASSERT_EQUAL(status, tvERROR_NONE);
+        UT_LOG_DEBUG("GetTVPictureMode status: %d, pictureMode: %s", status, pictureMode);
+        UT_ASSERT_STRING_EQUAL(pictureModes[i]->name, pictureMode);
+
+        if (status != tvERROR_NONE) {
+            UT_LOG_ERROR("Error in SetAndGetPictureMode, invoking TvTerm()");
+            status = TvTerm();
+            UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+            UT_LOG_DEBUG("TvTerm status: %d", status);
+            continue;
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+    UT_LOG_DEBUG("TvTerm status: %d", status);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test checks the functionality of setting and getting the color temperature Rgain in a TV settings module.
+*
+* This test case is designed to verify the SetColorTemp_Rgain_onSource and GetColorTemp_Rgain_onSource functions. It iterates over all color temperatures and source offsets, setting the Rgain value and then retrieving it to ensure the set and retrieved values match. This is done to ensure the correct functioning of the TV settings module in handling color temperature Rgain values.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 028@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetColorTempRgain(void)
+{
+    gTestID = 28;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int rgain = 0;
+    int setRgain = 0;
+    tvColorTemp_t colorTemp;
+    tvColorTempSourceOffset_t sourceId;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for(colorTemp = tvColorTemp_STANDARD; colorTemp < tvColorTemp_MAX; colorTemp++)
+    {
+        for(sourceId = ALL_SRC_OFFSET; sourceId < MAX_OFFSET; sourceId++)
+        {
+            for(setRgain = 0; setRgain <= 2047; setRgain++)
+            {
+                UT_LOG_DEBUG("Invoking SetColorTemp_Rgain_onSource with colorTemp: %d, rgain: %d, sourceId: %d, saveOnly: 0", colorTemp, setRgain, sourceId);
+                status = SetColorTemp_Rgain_onSource(colorTemp, setRgain, sourceId, 0);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                if(status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("SetColorTemp_Rgain_onSource failed with status: %d", status);
+                    continue;
+                }
+
+                UT_LOG_DEBUG("Invoking GetColorTemp_Rgain_onSource with colorTemp: %d, sourceId: %d", colorTemp, sourceId);
+                status = GetColorTemp_Rgain_onSource(colorTemp, &rgain, sourceId);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                if(status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("GetColorTemp_Rgain_onSource failed with status: %d", status);
+                    continue;
+                }
+
+                UT_LOG_DEBUG("Retrieved rgain: %d", rgain);
+                UT_ASSERT_EQUAL(rgain, setRgain);
+                if(rgain != setRgain)
+                {
+                    UT_LOG_ERROR("Mismatch in set and retrieved rgain values");
+                }
+            }
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the setting and getting of color temperature ggain in TV settings
+*
+* This test initializes the TV settings, loops through the different color temperatures and source ids, sets and gets the ggain value for each combination, verifies that the retrieved ggain value matches the set value, and finally de-initializes the TV settings. It uses Cunit's assertion functions to check the return values of the API calls.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 029@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetColorTempGgain(void)
+{
+    gTestID = 29;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int ggain = 0;
+    int set_ggain = 0;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for(tvColorTemp_t colorTemp = tvColorTemp_STANDARD; colorTemp < tvColorTemp_MAX; colorTemp++)
+    {
+        for(tvColorTempSourceOffset_t sourceId = ALL_SRC_OFFSET; sourceId < MAX_OFFSET; sourceId++)
+        {
+            for(set_ggain = 0; set_ggain <= 2047; set_ggain++)
+            {
+                UT_LOG_DEBUG("Invoking SetColorTemp_Ggain_onSource with colorTemp: %d, ggain: %d, sourceId: %d, saveOnly: 0", colorTemp, set_ggain, sourceId);
+                status = SetColorTemp_Ggain_onSource(colorTemp, set_ggain, sourceId, 0);
+                if(status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("SetColorTemp_Ggain_onSource failed with status: %d", status);
+                    UT_LOG_DEBUG("Invoking TvTerm");
+                    TvTerm();
+                    continue;
+                }
+
+                UT_LOG_DEBUG("Invoking GetColorTemp_Ggain_onSource with colorTemp: %d, sourceId: %d", colorTemp, sourceId);
+                status = GetColorTemp_Ggain_onSource(colorTemp, &ggain, sourceId);
+                if(status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("GetColorTemp_Ggain_onSource failed with status: %d", status);
+                    UT_LOG_DEBUG("Invoking TvTerm");
+                    TvTerm();
+                    continue;
+                }
+
+                UT_LOG_DEBUG("ggain: %d, status: %d", ggain, status);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                UT_ASSERT_EQUAL(ggain, set_ggain);
+            }
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to set and get the color temperature background gain in a TV setting
+*
+* This test sets the color temperature background gain for all color temperatures and source offsets, and then retrieves the set value to verify if the set and get operations are working as expected.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 030@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetColorTempBgain(void)
+{
+    gTestID = 30;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int bgain = 0;
+    int get_bgain = 0;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for (tvColorTemp_t colorTemp = tvColorTemp_STANDARD; colorTemp < tvColorTemp_MAX; colorTemp++)
+    {
+        for (tvColorTempSourceOffset_t sourceId = ALL_SRC_OFFSET; sourceId < MAX_OFFSET; sourceId++)
+        {
+            for (bgain = 0; bgain <= 2047; bgain++)
+            {
+                UT_LOG_DEBUG("Invoking SetColorTemp_Bgain_onSource with colorTemp: %d, bgain: %d, sourceId: %d, saveOnly: 0", colorTemp, bgain, sourceId);
+                status = SetColorTemp_Bgain_onSource(colorTemp, bgain, sourceId, 0);
+                if (status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("SetColorTemp_Bgain_onSource failed with status: %d", status);
+                    continue;
+                }
+
+                UT_LOG_DEBUG("Invoking GetColorTemp_Bgain_onSource with colorTemp: %d, sourceId: %d", colorTemp, sourceId);
+                status = GetColorTemp_Bgain_onSource(colorTemp, &get_bgain, sourceId);
+                if (status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("GetColorTemp_Bgain_onSource failed with status: %d", status);
+                    continue;
+                }
+
+                UT_LOG_DEBUG("bgain value retrieved: %d", get_bgain);
+                UT_ASSERT_EQUAL(bgain, get_bgain);
+            }
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to verify the functionality of setting and getting color temperature post offset on a source
+*
+* In this test, the SetColorTemp_R_post_offset_onSource and GetColorTemp_R_post_offset_onSource functions are invoked with various parameters to ensure they work as expected. The test checks if the set value is equal to the retrieved value for different color temperatures, source offsets, and saveOnly parameters. If the functions return an error, it is logged and the test continues with the next set of parameters.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 031@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetColorTemp_R_post_offset_onSource(void)
+{
+    gTestID = 31;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int rpostoffset_set, rpostoffset_get;
+    tvColorTemp_t colorTemp;
+    tvColorTempSourceOffset_t sourceId;
+    int saveOnly;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for (colorTemp = tvColorTemp_STANDARD; colorTemp < tvColorTemp_MAX; colorTemp++)
+    {
+        for (sourceId = ALL_SRC_OFFSET; sourceId < MAX_OFFSET; sourceId++)
+        {
+            for (rpostoffset_set = -1024; rpostoffset_set <= 1023; rpostoffset_set++)
+            {
+                for (saveOnly = 0; saveOnly <= 1; saveOnly++)
+                {
+                    UT_LOG_DEBUG("Invoking SetColorTemp_R_post_offset_onSource with colorTemp=%d, rpostoffset=%d, sourceId=%d, saveOnly=%d", colorTemp, rpostoffset_set, sourceId, saveOnly);
+                    status = SetColorTemp_R_post_offset_onSource(colorTemp, rpostoffset_set, sourceId, saveOnly);
+                    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                    if (status != tvERROR_NONE)
+                    {
+                        UT_LOG_ERROR("SetColorTemp_R_post_offset_onSource failed with status=%d", status);
+                        continue;
+                    }
+
+                    UT_LOG_DEBUG("Invoking GetColorTemp_R_post_offset_onSource with colorTemp=%d, sourceId=%d", colorTemp, sourceId);
+                    status = GetColorTemp_R_post_offset_onSource(colorTemp, &rpostoffset_get, sourceId);
+                    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                    if (status != tvERROR_NONE)
+                    {
+                        UT_LOG_ERROR("GetColorTemp_R_post_offset_onSource failed with status=%d", status);
+                        continue;
+                    }
+
+                    UT_LOG_DEBUG("Retrieved rpostoffset=%d", rpostoffset_get);
+                    UT_ASSERT_EQUAL(rpostoffset_set, rpostoffset_get);
+                }
+            }
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test checks the functionality of setting and getting color temperature G post offset
+*
+* This test case is designed to verify the functionality of the SetColorTemp_G_post_offset_onSource and GetColorTemp_G_post_offset_onSource functions. It checks if the color temperature G post offset can be set and retrieved correctly for all color temperatures and source offsets. The test iterates over all possible color temperatures and source offsets, sets a G post offset, retrieves it and checks if the retrieved value matches the set value.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 032@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetColorTempGPostOffset(void)
+{
+    gTestID = 32;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int gpostoffset_set, gpostoffset_get;
+    tvColorTemp_t colorTemp;
+    tvColorTempSourceOffset_t sourceId;
+
+    status = TvInit();
+    UT_LOG_DEBUG("Invoking TvInit");
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+    UT_LOG_DEBUG("TvInit status: %d", status);
+
+    for(colorTemp = tvColorTemp_STANDARD; colorTemp < tvColorTemp_MAX; colorTemp++)
+    {
+        for(sourceId = ALL_SRC_OFFSET; sourceId < MAX_OFFSET; sourceId++)
+        {
+            for(gpostoffset_set = -1024; gpostoffset_set <= 1023; gpostoffset_set++)
+            {
+                UT_LOG_DEBUG("Invoking SetColorTemp_G_post_offset_onSource with colorTemp: %d, gpostoffset: %d, sourceId: %d, saveOnly: 0", colorTemp, gpostoffset_set, sourceId);
+                status = SetColorTemp_G_post_offset_onSource(colorTemp, gpostoffset_set, sourceId, 0);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                UT_LOG_DEBUG("SetColorTemp_G_post_offset_onSource status: %d", status);
+
+                if(status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("SetColorTemp_G_post_offset_onSource failed with status: %d", status);
+                    continue;
+                }
+
+                UT_LOG_DEBUG("Invoking GetColorTemp_G_post_offset_onSource with colorTemp: %d, sourceId: %d", colorTemp, sourceId);
+                status = GetColorTemp_G_post_offset_onSource(colorTemp, &gpostoffset_get, sourceId);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                UT_ASSERT_EQUAL(gpostoffset_set, gpostoffset_get);
+                UT_LOG_DEBUG("GetColorTemp_G_post_offset_onSource status: %d, gpostoffset: %d", status, gpostoffset_get);
+
+                if(status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("GetColorTemp_G_post_offset_onSource failed with status: %d", status);
+                    continue;
+                }
+            }
+        }
+    }
+
+    status = TvTerm();
+    UT_LOG_DEBUG("Invoking TvTerm");
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+    UT_LOG_DEBUG("TvTerm status: %d", status);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to verify the functionality of setting and getting color temperature B post offset in L2 TV settings.
+*
+* In this test, the SetColorTemp_B_post_offset_onSource and GetColorTemp_B_post_offset_onSource functions are tested for all color temperatures and source offsets. The test ensures that the set value is correctly retrieved by the get function. This is important to ensure the correct functioning of color temperature settings in the TV.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 033@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetColorTempBPostOffset(void)
+{
+    gTestID = 33;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int bpostoffset_set, bpostoffset_get;
+    tvColorTemp_t colorTemp;
+    tvColorTempSourceOffset_t sourceId;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for (colorTemp = tvColorTemp_STANDARD; colorTemp < tvColorTemp_MAX; colorTemp++)
+    {
+        for (sourceId = ALL_SRC_OFFSET; sourceId < MAX_OFFSET; sourceId++)
+        {
+            for (bpostoffset_set = -1024; bpostoffset_set <= 1023; bpostoffset_set++)
+            {
+                UT_LOG_DEBUG("Invoking SetColorTemp_B_post_offset_onSource with colorTemp=%d, bpostoffset=%d, sourceId=%d, saveOnly=1", colorTemp, bpostoffset_set, sourceId);
+                status = SetColorTemp_B_post_offset_onSource(colorTemp, bpostoffset_set, sourceId, 1);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                if (status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("SetColorTemp_B_post_offset_onSource failed with status=%d", status);
+                    continue;
+                }
+
+                UT_LOG_DEBUG("Invoking GetColorTemp_B_post_offset_onSource with colorTemp=%d, sourceId=%d", colorTemp, sourceId);
+                status = GetColorTemp_B_post_offset_onSource(colorTemp, &bpostoffset_get, sourceId);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                if (status != tvERROR_NONE)
+                {
+                    UT_LOG_ERROR("GetColorTemp_B_post_offset_onSource failed with status=%d", status);
+                    continue;
+                }
+
+                UT_LOG_DEBUG("Retrieved bpostoffset=%d", bpostoffset_get);
+                UT_ASSERT_EQUAL(bpostoffset_set, bpostoffset_get);
+            }
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the disabling of WB Calibration Mode in TV settings
+*
+* This test case verifies if the White Balance (WB) Calibration Mode in TV settings can be successfully disabled and the status is correctly reflected. The test is crucial to ensure the correct functioning of the WB Calibration Mode toggle feature.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 034@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_DisableAndVerifyWBCalibrationMode(void)
+{
+    gTestID = 34;
+    tvError_t status;
+    bool value;
+
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking EnableWBCalibrationMode() with false");
+    status = EnableWBCalibrationMode(false);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetCurrentWBCalibrationMode()");
+    status = GetCurrentWBCalibrationMode(&value);
+    UT_LOG_DEBUG("Return status: %d, Output value: %d", status, value);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(value, false);
+
+    if (status != tvERROR_NONE || value != false)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        status = TvTerm();
+        UT_LOG_DEBUG("Return status: %d", status);
+        UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+    }
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test verifies the functionality of enabling and verifying the WB Calibration Mode in TV settings
+*
+* This test case invokes the TvInit() function to initialize the TV settings, then it enables the WB Calibration Mode by calling EnableWBCalibrationMode() function with value set to true. It then verifies the current WB Calibration Mode by calling GetCurrentWBCalibrationMode() function. The same steps are repeated to disable the WB Calibration Mode and verify it. Finally, it terminates the TV settings by calling TvTerm() function. The test case asserts that all the invoked functions return the expected status and the WB Calibration Mode is correctly enabled and disabled.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 035@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_EnableAndVerifyWBCalibrationMode(void)
+{
+    gTestID = 35;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    bool value;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking EnableWBCalibrationMode() with value set to true");
+    status = EnableWBCalibrationMode(true);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetCurrentWBCalibrationMode()");
+    status = GetCurrentWBCalibrationMode(&value);
+    UT_LOG_DEBUG("Return status: %d, Output value: %d", status, value);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(value, true);
+
+    UT_LOG_DEBUG("Invoking EnableWBCalibrationMode() with value set to false");
+    status = EnableWBCalibrationMode(false);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetCurrentWBCalibrationMode()");
+    status = GetCurrentWBCalibrationMode(&value);
+    UT_LOG_DEBUG("Return status: %d, Output value: %d", status, value);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(value, false);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to verify the functionality of setting and getting the Gamma Table in the TV settings.
+*
+* In this test, the SetGammaTable() and GetGammaTable() functions are tested to ensure they are working as expected. The test first initializes the TV, sets the Gamma Table, retrieves it, and then compares the set and retrieved values to ensure they match. If any of these steps fail, the test is considered failed.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 036@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetGammaTable(void)
+{
+    gTestID = 36;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t ret;
+    unsigned short size = 256;
+    unsigned short pData_R[size], pData_G[size], pData_B[size];
+    unsigned short getData_R[size], getData_G[size], getData_B[size];
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    ret = TvInit();
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetGammaTable() with valid buffers");
+    ret = SetGammaTable(pData_R, pData_G, pData_B, size);
+    UT_LOG_DEBUG("Return status: %d", ret);
+    UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+
+    if (ret != tvERROR_NONE) {
+        UT_LOG_ERROR("SetGammaTable failed, invoking TvTerm()");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetGammaTable() with valid buffers");
+    ret = GetGammaTable(getData_R, getData_G, getData_B, size);
+    UT_LOG_DEBUG("Return status: %d", ret);
+    UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+
+    for (int i = 0; i < size; i++) {
+        UT_ASSERT_EQUAL(pData_R[i], getData_R[i]);
+        UT_ASSERT_EQUAL(pData_G[i], getData_G[i]);
+        UT_ASSERT_EQUAL(pData_B[i], getData_B[i]);
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    ret = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", ret);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the functionality of GetDefaultGammaTable API
+*
+* This test case checks if the GetDefaultGammaTable API is able to fetch the default gamma table for a given color temperature. It also checks if the returned gamma values are within the expected range.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 037@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_GetDefaultGammaTable(void)
+{
+    gTestID = 37;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    unsigned short pData_R[256];
+    unsigned short pData_G[256];
+    unsigned short pData_B[256];
+    tvColorTemp_t colortemp = tvColorTemp_STANDARD;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetDefaultGammaTable() with valid color temperature and arrays");
+    status = GetDefaultGammaTable(colortemp, pData_R, pData_G, pData_B, 256);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+    for(int i = 0; i < 256; i++)
+    {
+        CU_ASSERT(pData_R[i] >= 0 && pData_R[i] <= 65535);
+        CU_ASSERT(pData_G[i] >= 0 && pData_G[i] <= 65535);
+        CU_ASSERT(pData_B[i] >= 0 && pData_B[i] <= 65535);
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to verify the Set and Get functionality of DvTmaxValue in the TV settings
+*
+* In this test, we first initialize the TV, then set a DvTmaxValue and try to retrieve the same value. The test is designed to ensure that the set and get functions for DvTmaxValue are working as expected.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 038@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetDvTmaxValue(void)
+{
+    gTestID = 38;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int setValue = 5000;
+    int getValue;
+
+    UT_LOG_DEBUG("Invoking TvInit");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetDvTmaxValue with value: %d", setValue);
+    status = SetDvTmaxValue(setValue);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE) {
+        UT_LOG_ERROR("SetDvTmaxValue failed with status: %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetDvTmaxValue");
+    status = GetDvTmaxValue(&getValue);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE) {
+        UT_LOG_ERROR("GetDvTmaxValue failed with status: %d", status);
+        UT_LOG_DEBUG("Invoking TvTerm");
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Retrieved value: %d", getValue);
+    UT_ASSERT_EQUAL(setValue, getValue);
+
+    UT_LOG_DEBUG("Invoking TvTerm");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the GetSupportedComponentColor API
+*
+* This test function initializes the TV settings, gets the supported component colors, verifies each color, and then de-initializes the TV settings. It uses the Cunit assertion functions to check the return status of each API call. It also uses the provided macro to compare the obtained component colors with the values in the platform-supported configurations file.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 039@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_GetSupportedComponentColor(void)
+{
+    gTestID = 39;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int blComponentColor;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetSupportedComponentColor() with valid address");
+    status = GetSupportedComponentColor(&blComponentColor);
+    UT_LOG_DEBUG("Return status: %d, Supported Component Colors: %d", status, blComponentColor);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_ASSERT_KVP_EQUAL_PROFILE_UINT32(blComponentColor, "SupportedComponentColor");
+
+    for (int i = 0; i < sizeof(blComponentColor)*8; i++)
+    {
+        if ((blComponentColor >> i) & 1)
+        {
+            UT_LOG_DEBUG("Component color at index %d is supported", i);
+        }
+        else
+        {
+            UT_LOG_DEBUG("Component color at index %d is not supported", i);
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to set and get the component saturation for a TV
+*
+* In this test, the component saturation of a TV is set and then retrieved to verify if the set value is correctly stored and retrieved. This is done for all possible color components. The test is important to ensure the correct functioning of the saturation setting and retrieval mechanism in the TV settings.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 040@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetComponentSaturation(void)
+{
+    gTestID = 40;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int saturation = 0;
+    int setSaturation = 0;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetCMSState(true)");
+    status = SetCMSState(true);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for(tvDataComponentColor_t color = tvDataColor_RED; color < tvDataColor_MAX; color++)
+    {
+        setSaturation = rand() % 101; // Random saturation value between 0 and 100
+
+        UT_LOG_DEBUG("Invoking SetCurrentComponentSaturation(%d, %d)", color, setSaturation);
+        status = SetCurrentComponentSaturation(color, setSaturation);
+        UT_LOG_DEBUG("SetCurrentComponentSaturation returned %d", status);
+        if(status != tvERROR_NONE)
+        {
+            UT_LOG_ERROR("SetCurrentComponentSaturation failed with status %d", status);
+            TvTerm(); // Call post-requisite API
+            continue;
+        }
+        UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+        UT_LOG_DEBUG("Invoking GetCurrentComponentSaturation(%d, &saturation)", color);
+        status = GetCurrentComponentSaturation(color, &saturation);
+        UT_LOG_DEBUG("GetCurrentComponentSaturation returned %d and saturation %d", status, saturation);
+        if(status != tvERROR_NONE)
+        {
+            UT_LOG_ERROR("GetCurrentComponentSaturation failed with status %d", status);
+            continue;
+        }
+        UT_ASSERT_EQUAL(status, tvERROR_NONE);
+        UT_ASSERT_EQUAL(saturation, setSaturation);
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test for setting and getting the component hue in L2 TV settings
+*
+* This test checks if the SetCurrentComponentHue and GetCurrentComponentHue functions work as expected. It sets the hue for each color component and then retrieves it to verify if the set value is correctly stored and retrieved. This is done for all color components and for hue values from 0 to 100.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 041@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetComponentHue(void)
+{
+    gTestID = 41;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int hue, hue_get;
+    tvDataComponentColor_t color;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetCMSState(true)");
+    status = SetCMSState(true);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for (color = tvDataColor_RED; color < tvDataColor_MAX; color++)
+    {
+        for (hue = 0; hue <= 100; hue++)
+        {
+            UT_LOG_DEBUG("Invoking SetCurrentComponentHue(%d, %d)", color, hue);
+            status = SetCurrentComponentHue(color, hue);
+            UT_LOG_DEBUG("Returned status: %d", status);
+            UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+            if (status != tvERROR_NONE)
+            {
+                UT_LOG_ERROR("SetCurrentComponentHue failed for color %d and hue %d", color, hue);
+                continue;
+            }
+
+            UT_LOG_DEBUG("Invoking GetCurrentComponentHue(%d)", color);
+            status = GetCurrentComponentHue(color, &hue_get);
+            UT_LOG_DEBUG("Returned hue: %d, status: %d", hue_get, status);
+            UT_ASSERT_EQUAL(status, tvERROR_NONE);
+            UT_ASSERT_EQUAL(hue, hue_get);
+
+            if (status != tvERROR_NONE || hue != hue_get)
+            {
+                UT_LOG_ERROR("GetCurrentComponentHue failed for color %d", color);
+                continue;
+            }
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test function is designed to test the setting and getting of component luma in the TV settings.
+*
+* In this test, the TV is initialized and the CMS state is set. Then, for each color component, the luma is set and then retrieved. The retrieved luma is then compared with the set luma to ensure they match. The TV is then terminated. This test is important to ensure that the luma can be correctly set and retrieved for each color component.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 042@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetComponentLuma(void)
+{
+    gTestID = 42;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t ret;
+    int luma, lumaSet;
+    tvDataComponentColor_t color;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    ret = TvInit();
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetCMSState(true)");
+    ret = SetCMSState(true);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    for (color = tvDataColor_NONE; color < tvDataColor_MAX; color++)
+    {
+        lumaSet = 15; // A valid luma value in the range of 0 to 30
+
+        UT_LOG_DEBUG("Invoking SetCurrentComponentLuma(%d, %d)", color, lumaSet);
+        ret = SetCurrentComponentLuma(color, lumaSet);
+        UT_LOG_DEBUG("Return status: %d", ret);
+        if (ret != tvERROR_NONE)
+        {
+            UT_LOG_ERROR("SetCurrentComponentLuma failed for color %d", color);
+            continue;
+        }
+        UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+
+        UT_LOG_DEBUG("Invoking GetCurrentComponentLuma(%d)", color);
+        ret = GetCurrentComponentLuma(color, &luma);
+        UT_LOG_DEBUG("Return status: %d, Luma: %d", ret, luma);
+        if (ret != tvERROR_NONE)
+        {
+            UT_LOG_ERROR("GetCurrentComponentLuma failed for color %d", color);
+            continue;
+        }
+        UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+        UT_ASSERT_EQUAL(luma, lumaSet);
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    ret = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to verify the functionality of setting and getting the CMS state in the TV settings.
+*
+* In this test, the CMS state is first set to true and then retrieved to verify if the set operation was successful. The same is then repeated with the CMS state set to false. The test ensures that the SetCMSState and GetCMSState functions are working as expected.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 043@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetCMSState(void)
+{
+    gTestID = 43;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    bool enableCMSState;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetCMSState() with enableCMSState set to true");
+    status = SetCMSState(true);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetCMSState()");
+    status = GetCMSState(&enableCMSState);
+    UT_LOG_DEBUG("Returned enableCMSState: %d, Return status: %d", enableCMSState, status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(enableCMSState, true);
+
+    UT_LOG_DEBUG("Invoking SetCMSState() with enableCMSState set to false");
+    status = SetCMSState(false);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetCMSState()");
+    status = GetCMSState(&enableCMSState);
+    UT_LOG_DEBUG("Returned enableCMSState: %d, Return status: %d", enableCMSState, status);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(enableCMSState, false);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test aims to verify the GetPQParameters function in the L2 TV Settings API
+*
+* This test case checks the correctness of the GetPQParameters function by setting various parameters using different functions and then retrieving them using GetPQParameters. The retrieved values are then compared with the expected values to verify the correctness of the function.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 044@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_TestGetPQParameters(void)
+{
+    gTestID = 44;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int value;
+    tvVideoSrcType_t videoSrcType;
+    tvVideoFormatType_t videoFormatType;
+    tvPQParameterIndex_t pqParamIndex;
+    int pq_mode = 0;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for(videoSrcType = VIDEO_SOURCE_ANALOGUE; videoSrcType < VIDEO_SOURCE_MAX; videoSrcType++)
+    {
+        for(videoFormatType = VIDEO_FORMAT_NONE; videoFormatType < VIDEO_FORMAT_MAX; videoFormatType++)
+        {
+            for(pq_mode = 0; pq_mode < PQ_MODE_MAX; pq_mode++)
+            {
+                UT_LOG_DEBUG("Invoking SaveBrightness(), SaveContrast(), SaveSaturation(), SaveHue() with videoSrcType=%d, pq_mode=%d, videoFormatType=%d, value=50", videoSrcType, pq_mode, videoFormatType);
+                status = SaveBrightness(videoSrcType, pq_mode, videoFormatType, 50);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                status = SaveContrast(videoSrcType, pq_mode, videoFormatType, 50);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                status = SaveSaturation(videoSrcType, pq_mode, videoFormatType, 50);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                status = SaveHue(videoSrcType, pq_mode, videoFormatType, 50);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+                UT_LOG_DEBUG("Invoking SetCurrentComponentSaturation() with blSaturationColor=%d, saturation=50", videoSrcType);
+                status = SetCurrentComponentSaturation(videoSrcType, 50);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+                UT_LOG_DEBUG("Invoking SaveDvTmaxValue() with state=LDIM_STATE_NONBOOST, value=500");
+                status = SaveDvTmaxValue(LDIM_STATE_NONBOOST, 500);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+                UT_LOG_DEBUG("Invoking SaveLowLatencyState() with videoSrcType=%d, pq_mode=%d, videoFormatType=%d, value=1", videoSrcType, pq_mode, videoFormatType);
+                status = SaveLowLatencyState(videoSrcType, pq_mode, videoFormatType, 1);
+                UT_ASSERT_EQUAL(status, tvERROR_NONE);
+
+                for(pqParamIndex = PQ_PARAM_BRIGHTNESS; pqParamIndex < PQ_PARAM_MAX; pqParamIndex++)
+                {
+                    UT_LOG_DEBUG("Invoking GetPQParams() with pqIndex=%d, videoSrcType=%d, videoFormatType=%d, pqParamIndex=%d", pq_mode, videoSrcType, videoFormatType, pqParamIndex);
+                    status = GetPQParams(pq_mode, videoSrcType, videoFormatType, pqParamIndex, &value);
+                    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+                    if(pqParamIndex == PQ_PARAM_LOWLATENCY_STATE)
+                    {
+                        UT_ASSERT_EQUAL(value, 1);
+                    }
+                    else if(pqParamIndex == PQ_PARAM_DOLBY_MODE)
+                    {
+                        UT_ASSERT_EQUAL(value, 500);
+                    }
+                    else
+                    {
+                        UT_ASSERT_EQUAL(value, 50);
+                    }
+                }
+            }
+        }
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test for getting TV Gamma Target
+*
+* This test case checks if the GetTVGammaTarget function is able to retrieve the correct gamma target values for different color temperatures. It ensures that the returned x and y values are within the expected range (0 to 1.0) for all color temperatures.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 045@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_GetTVGammaTarget(void)
+{
+    gTestID = 45;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    double x, y;
+    tvColorTemp_t colorTemp[] = {tvColorTemp_STANDARD, tvColorTemp_WARM, tvColorTemp_COLD, tvColorTemp_USER, tvColorTemp_BOOST_STANDARD, tvColorTemp_BOOST_WARM, tvColorTemp_BOOST_COLD, tvColorTemp_BOOST_USER, tvColorTemp_SUPERCOLD, tvColorTemp_BOOST_SUPERCOLD};
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    for(int i = 0; i < tvColorTemp_MAX; i++)
+    {
+        UT_LOG_DEBUG("Invoking GetTVGammaTarget() with colorTemp = %d", colorTemp[i]);
+        GetTVGammaTarget(colorTemp[i], &x, &y);
+        UT_LOG_DEBUG("Returned x = %f, y = %f", x, y);
+        CU_ASSERT(x >= 0 && x <= 1.0);
+        CU_ASSERT(y >= 0 && y <= 1.0);
+    }
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the Set and Get RGB Pattern functionality
+*
+* This test initializes the TV settings, sets the RGB pattern, gets the RGB pattern, and verifies that the set and get values match. It also checks the return status of each API call and logs the results. If any API call fails, it logs the error and terminates the TV settings.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 046@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetRGBPattern(void)
+{
+    gTestID = 46;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int r_set = 100, g_set = 150, b_set = 200;
+    int r_get, g_get, b_get;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE) {
+        UT_LOG_ERROR("TvInit failed with status: %d", status);
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking SetRGBPattern() with r=%d, g=%d, b=%d", r_set, g_set, b_set);
+    status = SetRGBPattern(r_set, g_set, b_set);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE) {
+        UT_LOG_ERROR("SetRGBPattern failed with status: %d", status);
+        TvTerm();
+        return;
+    }
+
+    UT_LOG_DEBUG("Invoking GetRGBPattern()");
+    status = GetRGBPattern(&r_get, &g_get, &b_get);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE) {
+        UT_LOG_ERROR("GetRGBPattern failed with status: %d", status);
+        TvTerm();
+        return;
+    }
+    UT_LOG_DEBUG("GetRGBPattern returned r=%d, g=%d, b=%d", r_get, g_get, b_get);
+
+    UT_ASSERT_EQUAL(r_get, r_set);
+    UT_ASSERT_EQUAL(g_get, g_set);
+    UT_ASSERT_EQUAL(b_get, b_set);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    status = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+    if (status != tvERROR_NONE) {
+        UT_LOG_ERROR("TvTerm failed with status: %d", status);
+    }
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the functionality of Set and Get Gray Pattern in TV settings
+*
+* This test case validates the Set and Get Gray Pattern functionality of the TV settings. It checks if the set value is correctly retrieved by the Get function. This is important to ensure the correct setting of Gray Pattern in the TV settings.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 047@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_SetAndGetGrayPattern(void)
+{
+    gTestID = 47;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t status;
+    int YUVValue = 100;
+    int get_YUVValue;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    status = TvInit();
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetGammaPatternMode(true)");
+    status = SetGammaPatternMode(true);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking SetGrayPattern(%d)", YUVValue);
+    status = SetGrayPattern(YUVValue);
+    UT_LOG_DEBUG("Return status: %d", status);
+    UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking GetGrayPattern()");
+    status = GetGrayPattern(&get_YUVValue);
+    UT_LOG_DEBUG("Return status: %d, YUVValue: %d", status, get_YUVValue);
+    UT_ASSERT_EQUAL(status, tvERROR_NONE);
+    UT_ASSERT_EQUAL(YUVValue, get_YUVValue);
+
+    if (status != tvERROR_NONE || YUVValue != get_YUVValue)
+    {
+        UT_LOG_DEBUG("Invoking TvTerm()");
+        status = TvTerm();
+        UT_LOG_DEBUG("Return status: %d", status);
+        UT_ASSERT_EQUAL_FATAL(status, tvERROR_NONE);
+    }
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief Test to verify the functionality of RetrieveOpenCircuitStatus API
+*
+* This test case verifies the functionality of the RetrieveOpenCircuitStatus API. It checks if the API is able to correctly retrieve the status of the open circuit in the TV settings. The test case invokes the TvInit() function to initialize the TV settings, then it calls the GetOpenCircuitStatus() function to retrieve the status of the open circuit. The test case asserts that the return values of these functions are as expected. If the status of the open circuit is greater than or equal to 1, it logs that a LED fault is detected. If the status is 0, it logs that no LED fault is detected. If the status is less than 0, it logs an error message. Finally, the test case calls the TvTerm() function to terminate the TV settings and asserts that its return value is as expected.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 048@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_RetrieveOpenCircuitStatus(void)
+{
+    gTestID = 48;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t ret;
+    int status;
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    ret = TvInit();
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+    UT_LOG_DEBUG("Return status: %d", ret);
+
+    UT_LOG_DEBUG("Invoking GetOpenCircuitStatus() with valid pointer");
+    ret = GetOpenCircuitStatus(&status);
+    UT_LOG_DEBUG("Open circuit status: %d, Return status: %d", status, ret);
+
+    if (status >= 1)
+    {
+        UT_LOG_INFO("LED fault detected");
+    }
+    else if (status == 0)
+    {
+        UT_LOG_INFO("No LED fault detected");
+    }
+    else
+    {
+        UT_LOG_ERROR("Invalid status value");
+    }
+
+    UT_ASSERT_EQUAL(ret, tvERROR_NONE);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    ret = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+    UT_LOG_DEBUG("Return status: %d", ret);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
+}
+
+/**
+* @brief This test checks the functionality of enabling and getting the dynamic contrast in TV settings
+*
+* In this test, the EnableDynamicContrast() and GetDynamicContrast() functions are tested to ensure they work as expected. The test first enables the dynamic contrast and checks if it is enabled. Then it disables the dynamic contrast and checks if it is disabled. This is done to ensure that the TV settings can correctly enable and disable the dynamic contrast and reflect the changes correctly.
+*
+* **Test Group ID:** 02@n
+* **Test Case ID:** 049@n
+*
+* **Test Procedure:**
+* Refer to UT specification documentation [tvSettings_L2_Low-Level_TestSpecification.md](../../docs/pages/tvSettings_L2_Low-Level_TestSpecification.md)
+*/
+
+void test_l2_tvSettings_EnableAndGetDynamicContrast(void)
+{
+    gTestID = 49;
+    UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
+    tvError_t ret;
+    char isDynamicContrastEnabled[10];
+
+    UT_LOG_DEBUG("Invoking TvInit()");
+    ret = TvInit();
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+    UT_LOG_DEBUG("Return status: %d", ret);
+
+    UT_LOG_DEBUG("Invoking EnableDynamicContrast() with true");
+    ret = EnableDynamicContrast(true);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+    UT_LOG_DEBUG("Return status: %d", ret);
+
+    UT_LOG_DEBUG("Invoking GetDynamicContrast()");
+    ret = GetDynamicContrast(isDynamicContrastEnabled);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+    UT_ASSERT_STRING_EQUAL_FATAL(isDynamicContrastEnabled, "enabled");
+    UT_LOG_DEBUG("Return status: %d, Dynamic Contrast: %s", ret, isDynamicContrastEnabled);
+
+    UT_LOG_DEBUG("Invoking EnableDynamicContrast() with false");
+    ret = EnableDynamicContrast(false);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+    UT_LOG_DEBUG("Return status: %d", ret);
+
+    UT_LOG_DEBUG("Invoking GetDynamicContrast()");
+    ret = GetDynamicContrast(isDynamicContrastEnabled);
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+    UT_ASSERT_STRING_EQUAL_FATAL(isDynamicContrastEnabled, "disabled");
+    UT_LOG_DEBUG("Return status: %d, Dynamic Contrast: %s", ret, isDynamicContrastEnabled);
+
+    UT_LOG_DEBUG("Invoking TvTerm()");
+    ret = TvTerm();
+    UT_ASSERT_EQUAL_FATAL(ret, tvERROR_NONE);
+    UT_LOG_DEBUG("Return status: %d", ret);
+
+    UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
 
 static UT_test_suite_t * pSuite = NULL;
 
 /**
- * @brief Register the main test(s) for this module
+ * @brief Register the main tests for this module
  *
  * @return int - 0 on success, otherwise failure
  */
-int test_l2_tvSettings_register ( void )
+
+int test_tvSettings_l2_register(void)
 {
-	/* add a suite to the registry */
-	pSuite = UT_add_suite( "[L2 tvSettings]", NULL, NULL );
-	if ( NULL == pSuite )
-	{
-		return -1;
-	}	
+    // Create the test suite
+    pSuite = UT_add_suite("[L2 tvSettings]", NULL, NULL);
+    if (pSuite == NULL)
+    {
+        return -1;
+    }
+    // List of test function names and strings
 
-	
-	UT_add_test( pSuite, "test_l2_tvSettings" ,test_l2_tvSettings );
+    UT_add_test( pSuite, "l2_tvSettings_GetSupportedVideoFormats", test_l2_tvSettings_GetSupportedVideoFormats);
+    UT_add_test( pSuite, "l2_tvSettings_GetCurrentVideoFormat_NoVideoPlayback", test_l2_tvSettings_GetCurrentVideoFormat_NoVideoPlayback);
+    UT_add_test( pSuite, "l2_tvSettings_VerifyCurrentVideoResolution", test_l2_tvSettings_VerifyCurrentVideoResolution);
+    UT_add_test( pSuite, "l2_tvSettings_VerifyFrameRateWhenStopped", test_l2_tvSettings_VerifyFrameRateWhenStopped);
+    UT_add_test( pSuite, "l2_tvSettings_GetTVSupportedVideoSources", test_l2_tvSettings_GetTVSupportedVideoSources);
+    UT_add_test( pSuite, "l2_tvSettings_VerifyNoVideoSource", test_l2_tvSettings_VerifyNoVideoSource);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetBacklight", test_l2_tvSettings_SetAndGetBacklight);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetBacklightFade", test_l2_tvSettings_SetAndGetBacklightFade);
+    UT_add_test( pSuite, "l2_tvSettings_GetSupportedBacklightModes", test_l2_tvSettings_GetSupportedBacklightModes);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetBacklightMode", test_l2_tvSettings_SetAndGetBacklightMode);
+    UT_add_test( pSuite, "l2_tvSettings_GetSupportedDimmingModes", test_l2_tvSettings_GetSupportedDimmingModes);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetDimmingMode", test_l2_tvSettings_SetAndGetDimmingMode);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetLocalDimmingLevel", test_l2_tvSettings_SetAndGetLocalDimmingLevel);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetBrightness", test_l2_tvSettings_SetAndGetBrightness);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetContrast", test_l2_tvSettings_SetAndGetContrast);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetSharpness", test_l2_tvSettings_SetAndGetSharpness);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetSaturation", test_l2_tvSettings_SetAndGetSaturation);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetHue", test_l2_tvSettings_SetAndGetHue);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetColorTemperature", test_l2_tvSettings_SetAndGetColorTemperature);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetAspectRatio", test_l2_tvSettings_SetAndGetAspectRatio);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetLowLatencyState", test_l2_tvSettings_SetAndGetLowLatencyState);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetDynamicContrast", test_l2_tvSettings_SetAndGetDynamicContrast);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetDynamicGamma", test_l2_tvSettings_SetAndGetDynamicGamma);
+    UT_add_test( pSuite, "l2_tvSettings_GetSupportedDolbyVisionModes", test_l2_tvSettings_GetSupportedDolbyVisionModes);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetDolbyVisionMode", test_l2_tvSettings_SetAndGetDolbyVisionMode);
+    UT_add_test( pSuite, "l2_tvSettings_GetTVSupportedPictureModes", test_l2_tvSettings_GetTVSupportedPictureModes);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetPictureMode", test_l2_tvSettings_SetAndGetPictureMode);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetColorTempRgain", test_l2_tvSettings_SetAndGetColorTempRgain);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetColorTempGgain", test_l2_tvSettings_SetAndGetColorTempGgain);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetColorTempBgain", test_l2_tvSettings_SetAndGetColorTempBgain);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetColorTemp_R_post_offset_onSource", test_l2_tvSettings_SetAndGetColorTemp_R_post_offset_onSource);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetColorTempGPostOffset", test_l2_tvSettings_SetAndGetColorTempGPostOffset);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetColorTempBPostOffset", test_l2_tvSettings_SetAndGetColorTempBPostOffset);
+    UT_add_test( pSuite, "l2_tvSettings_DisableAndVerifyWBCalibrationMode", test_l2_tvSettings_DisableAndVerifyWBCalibrationMode);
+    UT_add_test( pSuite, "l2_tvSettings_EnableAndVerifyWBCalibrationMode", test_l2_tvSettings_EnableAndVerifyWBCalibrationMode);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetGammaTable", test_l2_tvSettings_SetAndGetGammaTable);
+    UT_add_test( pSuite, "l2_tvSettings_GetDefaultGammaTable", test_l2_tvSettings_GetDefaultGammaTable);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetDvTmaxValue", test_l2_tvSettings_SetAndGetDvTmaxValue);
+    UT_add_test( pSuite, "l2_tvSettings_GetSupportedComponentColor", test_l2_tvSettings_GetSupportedComponentColor);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetComponentSaturation", test_l2_tvSettings_SetAndGetComponentSaturation);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetComponentHue", test_l2_tvSettings_SetAndGetComponentHue);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetComponentLuma", test_l2_tvSettings_SetAndGetComponentLuma);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetCMSState", test_l2_tvSettings_SetAndGetCMSState);
+    UT_add_test( pSuite, "l2_tvSettings_TestGetPQParameters", test_l2_tvSettings_TestGetPQParameters);
+    UT_add_test( pSuite, "l2_tvSettings_GetTVGammaTarget", test_l2_tvSettings_GetTVGammaTarget);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetRGBPattern", test_l2_tvSettings_SetAndGetRGBPattern);
+    UT_add_test( pSuite, "l2_tvSettings_SetAndGetGrayPattern", test_l2_tvSettings_SetAndGetGrayPattern);
+    UT_add_test( pSuite, "l2_tvSettings_RetrieveOpenCircuitStatus", test_l2_tvSettings_RetrieveOpenCircuitStatus);
+    UT_add_test( pSuite, "l2_tvSettings_EnableAndGetDynamicContrast", test_l2_tvSettings_EnableAndGetDynamicContrast);
 
-	return 0;
-} 
-/** @} */ // End of TV_Settings_HALTEST_L2
-/** @} */ // End of TV_Settings_HALTEST
-/** @} */ // End of TV_Settings
-/** @} */ // End of HPK
+    return 0;
+}

--- a/src/test_register.c
+++ b/src/test_register.c
@@ -1,88 +1,30 @@
-/**
-*  If not stated otherwise in this file or this component's LICENSE
-*  file the following copyright and licenses apply:
+/*
+* If not stated otherwise in this file or this component's LICENSE file the
+* following copyright and licenses apply:*
+* Copyright 2024 RDK Management
 *
-*  Copyright 2023 RDK Management
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
 *
-*  Licensed under the Apache License, Version 2.0 (the License);
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
 *
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an AS IS BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 */
 
-/**
- * @addtogroup HPK Hardware Porting Kit
- * @{
- * @par The Hardware Porting Kit
- * HPK is the next evolution of the well-defined Hardware Abstraction Layer
- * (HAL), but augmented with more comprehensive documentation and test suites
- * that OEM or SOC vendors can use to self-certify their ports before taking
- * them to RDKM for validation or to an operator for final integration and
- * deployment. The Hardware Porting Kit effectively enables an OEM and/or SOC
- * vendor to self-certify their own Video Accelerator devices, with minimal RDKM
- * assistance.
- *
- */
+/* L2 Testing Functions */
 
-/**
- * @addtogroup TV_Settings TV Settings Module
- * @{
- */
+extern int test_tvSettings_l2_register(void);
 
-/**
- * @addtogroup TV_Settings_HALTEST TV Settings HAL Tests
- * @{
- */
-
-/**
- * @defgroup TV_Settings_HALTEST_REGISTRATION Settings HAL Tests Registration File
- *  @{
- * @parblock
- *
- * ### Registration of tests for TV_Settings HAL :
- *
- * This is to ensure that the API meets the operational requirements of the module across all vendors.
- *
- * **Pre-Conditions:** None @n
- * **Dependencies:** None @n
- *
- * Refer to Device Settings HAL Documentation Guide : [tv-settings_halSpec.md](../../docs/pages/tv-settings_halSpec.md)
- *
- * @endparblock
- */
-
-/**
-* @file test_register.c
-*
-*/
-
-#include <ut.h>
-
-/**
- * @brief Register test functionality
- * 
- */
-
-/* L1 Testing Functions */
-extern int test_l1_tvSettings_register( void );
-
-
-int UT_register_APIDEF_l1_tests( void )
+int register_hal_l2_tests( void )
 {
-	int registerFailed=0;
+    int registerFailed=0;
 
-	registerFailed |= test_l1_tvSettings_register();
+    registerFailed |= test_tvSettings_l2_register();
 
-	return registerFailed;
+    return registerFailed;
 }
-/** @} */ // End of TV_Settings_HALTEST_REGISTRATION
-/** @} */ // End of TV_Settings_HALTEST
-/** @} */ // End of TV_Settings
-/** @} */ // End of HPK


### PR DESCRIPTION
Reason for change: Generate L2 tests for TV settings
Risks: Low
Test Procedure: Execute the hal test binary