### PR TITLE
gh #56 L1 and L2 changes for ODM API removal - Phase 1

### DIFF
--- a/src/test_l1_tvSettings.c
+++ b/src/test_l1_tvSettings.c
@@ -1328,8 +1328,8 @@ void test_l1_tvSettings_positive_GetCurrentVideoSource (void)
     UT_LOG("In:%s [%02d%03d]", __FUNCTION__,gTestGroup,gTestID);
 
     tvError_t result = tvERROR_NONE;
-    int tvVideoSource = 0;
-    int tvVideoSourceRetry = 0;
+    tvVideoSrcType_t tvVideoSource = 0;
+    tvVideoSrcType_t tvVideoSourceRetry = 0;
 
     /* Step 01: Calling tvsettings initialization and expecting the API to return success */
     result = TvInit();
@@ -1379,7 +1379,7 @@ void test_l1_tvSettings_negative_GetCurrentVideoSource (void)
     UT_LOG("In:%s [%02d%03d]", __FUNCTION__,gTestGroup,gTestID);
 
     tvError_t result = tvERROR_NONE ;
-    int tvVideoSource = 0;
+    tvVideoSrcType_t tvVideoSource = 0;
 
     if (extendedEnumsSupported == true)
     {

--- a/src/test_l2_tvSettings.c
+++ b/src/test_l2_tvSettings.c
@@ -472,7 +472,7 @@ void test_l2_tvSettings_VerifyNoVideoSource(void)
     UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     tvError_t status = tvERROR_NONE;
-    int32_t currentSource = 0;
+    tvVideoSrcType_t currentSource = 0;
 
     UT_LOG_DEBUG("Invoking TvInit()");
     status = TvInit();

--- a/src/test_l3_tvSettings.c
+++ b/src/test_l3_tvSettings.c
@@ -755,7 +755,7 @@ void test_l3_tvSettings_GetCurrentVideoSource(void)
     gTestID = 6;
     UT_LOG_INFO("In %s [%02d%03d]", __FUNCTION__, gTestGroup, gTestID);
     tvError_t ret = tvERROR_NONE;
-    int32_t currentSource = 0;
+    tvVideoSrcType_t currentSource = 0;
 
     UT_LOG_INFO("Calling GetCurrentVideoSource(OUT:currentSource:[])");
     ret = GetCurrentVideoSource(&currentSource);


### PR DESCRIPTION
HAL Header PR
https://github.com/rdkcentral/rdkv-halif-tvsettings/pull/47

**Main Objective**
The current activity focuses on removing soon-to-be deprecated ODM APIs and types from the TvSettings HAL headers, particularly those exposed to plugins and factory code.

**APIs Removed**
From include/tvSettingsExtODM.h:
int ReadCapabilitiesFromConfODM(...)
Defintion moved to the plugin.

_From include/tvSettingsODM.h:_
tvError_t **GetSupportedVideoFormatsODM**(unsigned int *videoFormats, unsigned short *numberOfFormats)
tvVideoHDRFormat_t **GetCurrentVideoFormatODM**(void)
tvError_t **GetTVSupportedDimmingModesODM**(char **dimmingModes, unsigned short *numDimmingModes)
Stubbed replacements are now present in tvSettings.h.
Conversion APIs like **ConvertVideoFormatToHDRFormatODM** and **ConvertHDRFormatToContentFormatODM**
Removed due to the deprecation of types like tvhdr_type_t and tvVideoHDRFormat_t.
int **GetPanelIDODM**(char *panelid)
Moved definition to the plugin. Further updates will encapsulate Panel ID retrieval in Phase 2.
tvError_t **TvSyncCalibrationInfoODM**()
Removed as the calibration data will now be handled differently.
tvError_t **GetTVSupportedDolbyVisionModesODM**(pic_modes_t *dvModes[],unsigned short *count)
tvError_t **SetWakeupConfig**(const tvWakeupSrcType_t src_type, const bool value);
tvError_t **SetTVDolbyVisionModeODM**(const char * dolbyMode);
int **GetCMSDefault**(tvComponentType_t component_type);

Note:
Additional function removals are included in preparation for Phase 2.

**Modified APIs**
_In include/tvSettings.h:_
tvError_t GetCurrentVideoSource(int *currentSource)
Updated to: tvError_t GetCurrentVideoSource(tvVideoSrcType_t *currentSource)
Rationale: To align with the expected type, ensuring consistency in API usage.


These changes are foundational for the overall API clean-up and ensure the TvSettings HAL interfaces are maintainable, and aligned with the upcoming architectural requirements.