### PR TITLE
test_l2_tvSettings_SetAndGetDolbyVisionMode loop accesses out-of-bounds index due to incorrect condition i <= getcount, causing VTS failures.

### DIFF
--- a/src/test_l2_tvSettings.c
+++ b/src/test_l2_tvSettings.c
@@ -1772,7 +1772,7 @@ void test_l2_tvSettings_SetAndGetDolbyVisionMode(void)
         UT_LOG_ERROR("GetTVSupportedDolbyVisionModes failed with status: %d", status);
     }
 
-    for ( int32_t i = 0; i <= getcount; i++ )
+    for ( int32_t i = 0; i < getcount; i++ )
     {
         UT_LOG_DEBUG("Invoking SetTVDolbyVisionMode with dolbyMode: %d", (*dvModes)[i]);
         status = SetTVDolbyVisionMode((*dvModes)[i]);


### PR DESCRIPTION
In the test_l2_tvSettings_SetAndGetDolbyVisionMode test case, the loop iterates up to getcount using the condition i <= getcount. Since the loop starts from 0, this results in the last iteration attempting to access an out-of-bounds index in the dvModes array, leading to garbage value access and VTS test failures.