### PR TITLE
gh #71 corrected the stream path for the L3 test cases

### DIFF
--- a/host/tests/tvSettings_L3_Tests/tvSettings_test04_CheckVideoSource.py
+++ b/host/tests/tvSettings_L3_Tests/tvSettings_test04_CheckVideoSource.py
@@ -74,8 +74,15 @@ class tvSettings_test04_CheckVideoSource(tvSettingsHelperClass):
 
         # Iterate through streams, but only for VIDEO_SOURCE_IP
         for stream in streams:
-            # Start the stream playback
-            self.testPlayer.play(stream)
+
+            # Download the individual stream
+            self.testDownloadAssetsByUrl(stream)
+
+            streamFullPath = os.path.join(self.targetWorkspace, os.path.basename(stream))
+
+            # Play the stream
+            self.testPlayer.play(streamFullPath)
+
             time.sleep(3)  # Wait for a moment to let the stream start
 
             self.log.stepStart(f'Video Source Level: VIDEO_SOURCE_IP Stream: {stream}')

--- a/host/tests/tvSettings_L3_Tests/tvSettings_test55_SaveGammaTable.py
+++ b/host/tests/tvSettings_L3_Tests/tvSettings_test55_SaveGammaTable.py
@@ -134,24 +134,19 @@ class tvSettings_test55_SaveGammaTable(tvSettingsHelperClass):
         # Initialize the tvSettings module
         self.testtvSettings.initialise()
 
-        # Get the list of streams from the test setup
-        streams = self.testSetup.get("assets").get("device").get(self.testName).get("streams")
-
         # Set gamma values for the color temperatures
         gamma_values = self.setGammaValues()  # This should return a list of (color_temp, red, green, blue) tuples
         colorTemperatures = self.testtvSettings.getColorTemperatureInfo()  # Get the available color temperatures
 
         # Loop through streams
-        for stream in streams:
-
-            streamPath =  os.path.join(self.targetWorkspace, os.path.basename(stream))
+        for stream in self.testStreams:
 
             # Play the stream
-            self.testPlayer.play(streamPath)
+            self.testPlayer.play(stream)
             time.sleep(3)  # Allow the stream to start
 
             # Log details for the current stream
-            self.log.stepStart(f'Stream: {streamPath}')
+            self.log.stepStart(f'Stream: {stream}')
 
             # Loop through the combinations and assign color temperatures
             for index, (color_temp, red, green, blue, description) in enumerate(gamma_values):


### PR DESCRIPTION
tvSettings_test04_CheckVideoSource - VTS is configured to use a target workspace where streams are copied from localhost. However, in self.testPlayer.play(stream), the stream path is referenced incorrectly. The function expects the stream in a different relative path than its actual location in the target workspace. This mismatch leads to the player not finding the stream correctly.