### PR TITLE
Use dimming modes from yaml instead of hard coded value and case correction of dimming mode in yaml

### DIFF
--- a/profiles/sink/Sink_4K_TvSettings.yaml
+++ b/profiles/sink/Sink_4K_TvSettings.yaml
@@ -842,11 +842,13 @@ tvSettings:
   # tvDimmingMode_MAX     = 0x03  //!< End of enum
   DimmingMode:
     range:
-      - fixed
-      - global
+      - Fixed
+      - Global
+      # - Local
     index:
       - 0x00 #tvDimmingMode_Fixed
       - 0x02 #tvDimmingMode_Global
+      # - 0x01 #tvDimmingMode_Local
     # Entertaiment
     # Dynamic
     # Energy saving
@@ -892,7 +894,7 @@ tvSettings:
       - HDMI3
       - IP
       - Tuner
-    numberOfDimmingModes: 2 #local #fixed
+    numberOfDimmingModes: 2 #Local #Fixed
 
 
   DolbyVisionMode:

--- a/profiles/sink/Sink_4K_TvSettings.yaml
+++ b/profiles/sink/Sink_4K_TvSettings.yaml
@@ -844,11 +844,11 @@ tvSettings:
     range:
       - Fixed
       - Global
-      # - Local
+      - Local
     index:
       - 0x00 #tvDimmingMode_Fixed
       - 0x02 #tvDimmingMode_Global
-      # - 0x01 #tvDimmingMode_Local
+      - 0x01 #tvDimmingMode_Local
     # Entertaiment
     # Dynamic
     # Energy saving
@@ -894,7 +894,7 @@ tvSettings:
       - HDMI3
       - IP
       - Tuner
-    numberOfDimmingModes: 2 #Local #Fixed
+    numberOfDimmingModes: 3 #Local #Fixed #Global
 
 
   DolbyVisionMode:

--- a/src/test_l2_tvSettings.c
+++ b/src/test_l2_tvSettings.c
@@ -870,6 +870,8 @@ void test_l2_tvSettings_SetAndGetDimmingMode(void)
     char getDimmingMode[10] = { 0 };
     int32_t count = 0;
     uint16_t numDimmingModes = 0;
+    char keyValue[UT_KVP_MAX_ELEMENT_SIZE] = { 0 };
+    char dimmingModeStr[UT_KVP_MAX_ELEMENT_SIZE] = { 0 };
 
     status = TvInit();
     UT_LOG_DEBUG("Invoking TvInit");
@@ -894,15 +896,8 @@ void test_l2_tvSettings_SetAndGetDimmingMode(void)
 
     for(int32_t j = 0; j < numDimmingModes; j++)
     {
-        // Convert tvDimmingMode_t to string for SetTVDimmingMode
-        const char *dimmingModeStr = NULL;
-        if (supportedDimmingModes[j] == tvDimmingMode_Fixed) {
-            dimmingModeStr = "fixed";
-        } else if (supportedDimmingModes[j] == tvDimmingMode_Global) {
-            dimmingModeStr = "global";
-        } else if (supportedDimmingModes[j] == tvDimmingMode_Local) {
-            dimmingModeStr = "local";
-        }
+        snprintf(keyValue, UT_KVP_MAX_ELEMENT_SIZE, "tvSettings/DimmingMode/range/%d", j);
+        UT_KVP_PROFILE_GET_STRING(keyValue,dimmingModeStr);
 
         if (dimmingModeStr != NULL) {
             status = SetTVDimmingMode(dimmingModeStr);


### PR DESCRIPTION
- In L2-SetAndGetDimmingMode, Use dimming modes from yaml instead of hard coded values in code
- Updated yaml to use "Fixed/Global" (case corrected) instead of "fixed/global"